### PR TITLE
fix: relax HttpRequest handler signature constraints

### DIFF
--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -76,6 +76,23 @@ def validate_http(
                 f"as its first positional argument"
             )
 
+        # Guard against first positional parameter name conflicting with injected parameter names.
+        # If the request param shares a name with an injected input (body/query/path/headers/req_model),
+        # the wrapper would call func(http_request, body=parsed_body) causing TypeError at runtime.
+        _injected: dict[str, Any] = {
+            "body": body,
+            "query": query,
+            "path": path,
+            "headers": headers,
+            "req_model": request_model,
+        }
+        if request_param_name in _injected and _injected[request_param_name] is not None:
+            raise ValueError(
+                f"Function {func.__name__}: first positional parameter '{request_param_name}' "
+                f"conflicts with a @validate_http injected parameter of the same name. "
+                f"Rename it (e.g. to 'req' or 'http_request')."
+            )
+
         def wrapper(*args: Any, **kwargs: Any) -> HttpResponse:
             # Extract HttpRequest from args
             http_request = None

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -315,6 +315,71 @@ class TestConfigurationErrors:
             def handler(*, request: HttpRequest) -> HttpResponse:
                 return HttpResponse("ok")
 
+    def test_request_param_name_conflicts_with_body_injection(self) -> None:
+        """Test ValueError when the first positional param is named 'body' and body= is set."""
+
+        with pytest.raises(
+            ValueError,
+            match="conflicts with a @validate_http injected parameter of the same name",
+        ):
+
+            @validate_http(body=UserModel)
+            def handler(body: HttpRequest, user: UserModel) -> HttpResponse:
+                return HttpResponse("ok")
+
+    def test_request_param_name_conflicts_with_query_injection(self) -> None:
+        """Test ValueError when the first positional param is named 'query' and query= is set."""
+
+        with pytest.raises(
+            ValueError,
+            match="conflicts with a @validate_http injected parameter of the same name",
+        ):
+
+            @validate_http(query=QueryModel)
+            def handler(query: HttpRequest) -> HttpResponse:
+                return HttpResponse("ok")
+
+    def test_request_param_name_conflicts_with_path_injection(self) -> None:
+        """Test ValueError when the first positional param is named 'path' and path= is set."""
+
+        with pytest.raises(
+            ValueError,
+            match="conflicts with a @validate_http injected parameter of the same name",
+        ):
+
+            @validate_http(path=PathModel)
+            def handler(path: HttpRequest) -> HttpResponse:
+                return HttpResponse("ok")
+
+    def test_request_param_name_conflicts_with_headers_injection(self) -> None:
+        """Test ValueError when the first positional param is named 'headers' and headers= is set."""
+
+        with pytest.raises(
+            ValueError,
+            match="conflicts with a @validate_http injected parameter of the same name",
+        ):
+
+            @validate_http(headers=HeaderModel)
+            def handler(headers: HttpRequest) -> HttpResponse:
+                return HttpResponse("ok")
+
+    def test_request_param_named_body_without_injection_is_allowed(self) -> None:
+        """No error when param is named 'body' but no body= is configured."""
+
+        # Should not raise – body injection is not enabled
+        @validate_http()
+        def handler(body: HttpRequest) -> HttpResponse:
+            return HttpResponse("ok")
+
+    def test_safe_request_param_names_are_allowed(self) -> None:
+        """Standard param names like 'req' / 'request' / 'http_request' must not raise."""
+
+        for name in ("req", "request", "http_request"):
+
+            @validate_http(body=UserModel)
+            def handler(req: HttpRequest, body: UserModel) -> HttpResponse:  # noqa: F811
+                return HttpResponse("ok")
+
     @pytest.mark.skip("Async handler support requires further investigation")
     def test_async_handler(self, mock_request_factory: RequestFactory) -> None:
         """Test async handler support."""


### PR DESCRIPTION
## Summary
- allow non-standard request parameter names for validated handlers
- resolve the request from the first positional handler parameter
- add regression coverage for custom request parameter names and invalid keyword-only request signatures

## Validation
- make check-all

## Linked issue
- Closes #53