### PR TITLE
refactor: reuse parsed request inputs in validation decorator

### DIFF
--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -123,10 +123,10 @@ def validate_http(
                 if query is not None:
                     try:
                         # Always validate query parameters, even if function doesn't use them
-                        adapter.parse_query(http_request, query)
+                        parsed_query = adapter.parse_query(http_request, query)
                         # If function expects query parameter, pass it
                         if "query" in func_params:
-                            parsed_inputs["query"] = adapter.parse_query(http_request, query)
+                            parsed_inputs["query"] = parsed_query
                     except Exception as e:
                         return format_error_response(e, 422)
 
@@ -134,10 +134,10 @@ def validate_http(
                 if path is not None:
                     try:
                         # Always validate path parameters, even if function doesn't use them
-                        adapter.parse_path(http_request, path)
+                        parsed_path = adapter.parse_path(http_request, path)
                         # If function expects path parameter, pass it
                         if "path" in func_params:
-                            parsed_inputs["path"] = adapter.parse_path(http_request, path)
+                            parsed_inputs["path"] = parsed_path
                     except Exception as e:
                         return format_error_response(e, 422)
 
@@ -145,10 +145,10 @@ def validate_http(
                 if headers is not None:
                     try:
                         # Always validate headers, even if function doesn't use them
-                        adapter.parse_headers(http_request, headers)
+                        parsed_headers = adapter.parse_headers(http_request, headers)
                         # If function expects headers parameter, pass it
                         if "headers" in func_params:
-                            parsed_inputs["headers"] = adapter.parse_headers(http_request, headers)
+                            parsed_inputs["headers"] = parsed_headers
                     except Exception as e:
                         return format_error_response(e, 422)
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -12,6 +12,7 @@ from azure_functions_validation import validate_http
 
 RequestFactory: TypeAlias = Callable[..., HttpRequest]
 
+
 # Test models
 class UserModel(BaseModel):
     """Test model for user data."""
@@ -135,6 +136,49 @@ class TestSuccessfulValidation:
         response = handler(request)
 
         assert response.status_code == 200
+
+    def test_request_inputs_are_parsed_once(self, mock_request_factory: RequestFactory) -> None:
+        """Test that configured request inputs are parsed only once."""
+
+        adapter = Mock()
+        adapter.parse_body.return_value = UserModel(name="Robin", age=26)
+        adapter.parse_query.return_value = QueryModel(limit=10, offset=0)
+        adapter.parse_path.return_value = PathModel(user_id=42)
+        adapter.parse_headers.return_value = HeaderModel(
+            authorization="Bearer token123",
+            user_agent="Mozilla",
+        )
+        adapter.serialize.return_value = (json.dumps({"message": "ok"}), "application/json")
+
+        @validate_http(
+            body=UserModel,
+            query=QueryModel,
+            path=PathModel,
+            headers=HeaderModel,
+            adapter=adapter,
+        )
+        def handler(
+            req: HttpRequest,
+            body: UserModel,
+            query: QueryModel,
+            path: PathModel,
+            headers: HeaderModel,
+        ) -> dict[str, str]:
+            return {"message": "ok"}
+
+        request = mock_request_factory(
+            body=b'{"name": "Robin", "age": 26}',
+            params={"limit": "10", "offset": "0"},
+            route_params={"user_id": "42"},
+            headers={"authorization": "Bearer token123", "user_agent": "Mozilla"},
+        )
+        response = handler(request)
+
+        assert response.status_code == 200
+        adapter.parse_body.assert_called_once_with(request, UserModel)
+        adapter.parse_query.assert_called_once_with(request, QueryModel)
+        adapter.parse_path.assert_called_once_with(request, PathModel)
+        adapter.parse_headers.assert_called_once_with(request, HeaderModel)
 
 
 # Test validation errors


### PR DESCRIPTION
## Summary
- parse query, path, and header inputs once per request path
- reuse validated values when injecting handler arguments
- add regression coverage for single-pass request parsing

## Validation
- make check-all

## Linked issue
- Closes #55