### PR TITLE
chore: restore validation lint and test hygiene

### DIFF
--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -78,9 +78,9 @@ def validate_http(
                 f"as its first positional argument"
             )
 
-        # Guard against first positional parameter name conflicting with injected parameter names.
-        # If the request param shares a name with an injected input (body/query/path/headers/req_model),
-        # the wrapper would call func(http_request, body=parsed_body) causing TypeError at runtime.
+        # Guard against first positional parameter name conflicting with injected names.
+        # If it shares a name with body/query/path/headers/req_model, the wrapper
+        # would inject the parsed value twice and fail at runtime.
         _injected: dict[str, Any] = {
             "body": body,
             "query": query,
@@ -207,9 +207,7 @@ def validate_http(
                         body=content, status_code=200, headers={"Content-Type": content_type}
                     )
                 except Exception as e:
-                    response_error = ResponseValidationError(
-                        f"Response validation failed: {e}"
-                    )
+                    response_error = ResponseValidationError(f"Response validation failed: {e}")
                     # Check global error handler first
                     global_handler = GlobalErrorHandlerRegistry.get_handler(response_error)
                     if global_handler is not None:

--- a/src/azure_functions_validation/openapi.py
+++ b/src/azure_functions_validation/openapi.py
@@ -92,7 +92,10 @@ def get_validation_error_examples(request_model: Type[BaseModel]) -> List[Dict[s
                             "detail": [
                                 {
                                     "loc": ["body", field_name],
-                                    "msg": f"String should have at least {field_schema['minLength']} character(s)",
+                                    "msg": (
+                                        "String should have at least "
+                                        f"{field_schema['minLength']} character(s)"
+                                    ),
                                     "type": "string_too_short",
                                 }
                             ]
@@ -107,7 +110,10 @@ def get_validation_error_examples(request_model: Type[BaseModel]) -> List[Dict[s
                             "detail": [
                                 {
                                     "loc": ["body", field_name],
-                                    "msg": f"String should match pattern '{field_schema['pattern']}'",
+                                    "msg": (
+                                        "String should match pattern "
+                                        f"'{field_schema['pattern']}'"
+                                    ),
                                     "type": "string_pattern_mismatch",
                                 }
                             ]

--- a/tests/_test_app/function_app.py
+++ b/tests/_test_app/function_app.py
@@ -5,7 +5,6 @@ import azure.functions as func
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from azure_functions_validation import validate_http
-from azure_functions_validation import validate_http
 
 
 # --- Test Models ---

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -396,7 +396,7 @@ class TestConfigurationErrors:
                 return HttpResponse("ok")
 
     def test_request_param_name_conflicts_with_headers_injection(self) -> None:
-        """Test ValueError when the first positional param is named 'headers' and headers= is set."""
+        """Test a conflict when the first positional parameter is named `headers`."""
 
         with pytest.raises(
             ValueError,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,26 +1,16 @@
 import json
 from typing import Any, Dict, Optional
 
+import azure.functions as func
+from function_app import (
+    create_comment,
+    create_post,
+    create_user,
+    create_user_async,
+    create_user_direct_response,
+    update_user,
+)
 import pytest
-
-import azure.functions as func
-from function_app import (
-    create_comment,
-    create_post,
-    create_user,
-    create_user_async,
-    create_user_direct_response,
-    update_user,
-)
-import azure.functions as func
-from function_app import (
-    create_comment,
-    create_post,
-    create_user,
-    create_user_async,
-    create_user_direct_response,
-    update_user,
-)
 
 
 class MockHttpRequest:


### PR DESCRIPTION
## Summary

Restore a green baseline for alidation by fixing the lint and test hygiene issues that were already present on main.

## Changes

- wrap long strings in src/azure_functions_validation/openapi.py
- simplify an overlong comment in src/azure_functions_validation/decorator.py
- remove duplicate imports in test fixtures and integration tests
- shorten an overlong decorator test docstring

## Validation

- make check-all
