### PR TITLE
docs: expand focused validation example docs

### DIFF
--- a/docs/examples/async_validation.md
+++ b/docs/examples/async_validation.md
@@ -1,0 +1,32 @@
+# Async Validation
+
+Use this example when you want `validate_http` on an `async def` Azure Functions Python v2 handler.
+
+## What It Shows
+
+- typed body validation on an async handler
+- typed response validation and serialization
+- a minimal await boundary inside the handler body
+
+## Example Path
+
+- `examples/async_validation`
+
+## Key Pattern
+
+```python
+@validate_http(body=AsyncGreetingRequest, response_model=AsyncGreetingResponse)
+async def async_validation(
+    req: func.HttpRequest, body: AsyncGreetingRequest
+) -> AsyncGreetingResponse:
+    await asyncio.sleep(0)
+    return AsyncGreetingResponse(message=f"Hello {body.name}")
+```
+
+## Smoke Coverage
+
+This example is smoke-tested for:
+
+- a valid typed response
+- a structured `422` validation error on invalid input
+

--- a/docs/examples/openapi_aligned_validation.md
+++ b/docs/examples/openapi_aligned_validation.md
@@ -1,0 +1,34 @@
+# OpenAPI-Aligned Validation
+
+Use this example when you want runtime validation and reusable validation error metadata to stay aligned.
+
+## What It Shows
+
+- request validation with `validate_http`
+- typed response validation
+- reusable `422` schema and examples for documentation tooling
+
+## Example Path
+
+- `examples/openapi_aligned_validation`
+
+## Key Pattern
+
+```python
+OPENAPI_422_SCHEMA = generate_422_error_schema(WidgetRequest)
+OPENAPI_422_EXAMPLES = get_validation_error_examples(WidgetRequest)
+
+
+@validate_http(body=WidgetRequest, response_model=WidgetResponse)
+def create_widget(req: func.HttpRequest, body: WidgetRequest) -> WidgetResponse:
+    return WidgetResponse(id=1, name=body.name)
+```
+
+## Smoke Coverage
+
+This example is smoke-tested for:
+
+- a valid typed response
+- exported `422` schema metadata
+- exported `422` example payloads
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,3 +46,4 @@ See the Usage guide for more patterns.
 - Representative: `examples/hello_validation`
 - Complex: `examples/profile_validation`
 - Focused: `examples/async_validation`
+- Focused: `examples/openapi_aligned_validation`

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,3 +9,6 @@
 | Focused | `examples/async_validation` | Async handler validation with typed request and response models. |
 | Focused | `examples/custom_error_handler` | Custom validation error formatting for HTTP handlers. |
 | Focused | `examples/openapi_aligned_validation` | Validation helpers prepared for OpenAPI-aligned error documentation. |
+
+Focused examples are intentionally smaller than the representative and complex examples.
+They exist to keep one advanced pattern easy to inspect and easy to smoke-test.

--- a/examples/async_validation/README.md
+++ b/examples/async_validation/README.md
@@ -8,3 +8,7 @@ It demonstrates:
 - typed body validation
 - typed JSON response serialization
 
+Expected outcomes:
+
+- valid JSON body -> `200` typed JSON response
+- invalid JSON body -> `422` structured validation error

--- a/examples/openapi_aligned_validation/README.md
+++ b/examples/openapi_aligned_validation/README.md
@@ -4,3 +4,9 @@ This example shows how to keep validation behavior and OpenAPI-oriented error me
 
 It does not require `azure-functions-openapi` directly. Instead, it uses the OpenAPI helper utilities
 from `azure-functions-validation` to prepare reusable `422` schema and example payload data.
+
+Expected outcomes:
+
+- valid request body -> typed `WidgetResponse`
+- invalid request body -> structured `422` validation error
+- reusable `OPENAPI_422_SCHEMA` and `OPENAPI_422_EXAMPLES` for downstream documentation tooling

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,8 @@ nav:
   - Examples:
       - Basic Validation: examples/basic_validation.md
       - Query/Path/Header: examples/query_validation.md
+      - Async Validation: examples/async_validation.md
+      - OpenAPI-Aligned Validation: examples/openapi_aligned_validation.md
   - Troubleshooting: troubleshooting.md
   - Security: security.md
   - Changelog: changelog.md


### PR DESCRIPTION
Closes #73

## Summary
- add focused docs pages for async and OpenAPI-aligned validation examples
- clarify the role of focused examples in the example set
- tighten example READMEs around the expected runtime outcomes

## Validation
- make check-all
- make docs