### PR TITLE
docs: document package ownership boundary and expand API reference

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,30 +4,136 @@
 
 ### `validate_http(...)`
 
-Main decorator for request/response validation.
+Main decorator for request/response validation on Azure Functions HTTP handlers.
 
 **Parameters**
-- `body`: Pydantic model class for request body validation
-- `query`: Pydantic model class for query parameter validation
-- `path`: Pydantic model class for path parameter validation
-- `headers`: Pydantic model class for header validation
-- `request_model`: Shorthand for body model (alias for `body`)
-- `response_model`: Pydantic model class for response validation
-- `error_formatter`: Custom error formatter function
-- `adapter`: Custom validation adapter instance
 
-## Functions
+| Parameter | Type | Description |
+|---|---|---|
+| `body` | `type[BaseModel]` | Pydantic model for request body |
+| `query` | `type[BaseModel]` | Pydantic model for query parameters |
+| `path` | `type[BaseModel]` | Pydantic model for path parameters |
+| `headers` | `type[BaseModel]` | Pydantic model for request headers |
+| `request_model` | `type[BaseModel]` | Shorthand alias for `body` |
+| `response_model` | `type[BaseModel] \| GenericAlias` | Pydantic model for response validation |
+| `error_formatter` | `Callable[[Exception, int], dict]` | Custom per-handler error formatter |
+| `adapter` | `ValidationAdapter` | Custom validation adapter (defaults to `PydanticAdapter`) |
 
-- `register_global_error_handler(exception_type, handler)`
-- `clear_global_error_handlers()`
-- `get_contract_schema(contract_type)`
-- `get_request_contract_metadata(...)`
-- `get_response_contract_metadata(response_model)`
-- `get_validation_error_contract(request_model)`
-- `describe_validation_contract(...)`
-- `generate_422_error_schema(model)`
-- `get_validation_error_examples(model)`
-- `contract_test()`
-- `verify_contracts(function, test_data, ...)`
+**Validation error response shape** (HTTP 422):
 
-See README for detailed examples and error response formats.
+```json
+{
+  "detail": [
+    {
+      "loc": ["body", "field_name"],
+      "msg": "Field required",
+      "type": "missing"
+    }
+  ]
+}
+```
+
+---
+
+## Validation Metadata
+
+These functions describe the runtime validation contracts owned by this package.
+They are intended to be consumed by documentation tooling such as `azure-functions-openapi`.
+
+### `describe_validation_contract(...)`
+
+Returns a combined description of request, response, and 422 error contracts.
+
+```python
+from azure_functions_validation import describe_validation_contract
+
+contract = describe_validation_contract(
+    body=CreateUserRequest,
+    response_model=CreateUserResponse,
+)
+# contract["request"]  → request source schemas
+# contract["response"] → response schema
+# contract["errors"]["validation"] → 422 error schema and examples
+```
+
+### `get_request_contract_metadata(...)`
+
+Describes the validated request sources (body, query, path, headers) with their schemas.
+
+### `get_response_contract_metadata(response_model)`
+
+Describes the validated response type and its schema.
+
+### `get_validation_error_contract(request_model)`
+
+Returns the canonical 422 error contract: status code, schema, and examples derived from the request model.
+
+### `get_contract_schema(contract_type)`
+
+Returns a JSON schema for any Pydantic model or generic type.
+
+---
+
+## OpenAPI Helpers
+
+These functions produce OpenAPI-compatible data derived from the validation contract.
+They delegate to `metadata.py` — they do **not** own the contract logic.
+
+> **Note**: OpenAPI document generation belongs to `azure-functions-openapi`.
+> These helpers exist only to make the validation contract consumable in OpenAPI format.
+
+### `generate_422_error_schema(request_model)`
+
+Returns the OpenAPI schema object for 422 validation error responses.
+
+### `get_validation_error_examples(request_model)`
+
+Returns a list of example 422 error response bodies, derived from the request model's field constraints.
+
+---
+
+## Error Handling
+
+### `ResponseValidationError`
+
+Raised when response validation fails. Can be caught with a global error handler.
+
+### `ErrorFormatter`
+
+Type alias for `Callable[[Exception, int], dict]`. Used with the `error_formatter` parameter of `validate_http`.
+
+### `register_global_error_handler(exception_type, handler)`
+
+Registers a handler for a specific exception type. The most specific matching type (by MRO) is used when multiple handlers match.
+
+```python
+from azure_functions_validation import register_global_error_handler
+import azure.functions as func
+
+
+def handle_auth_error(exc: Exception) -> func.HttpResponse:
+    return func.HttpResponse(status_code=401, body="Unauthorized")
+
+
+register_global_error_handler(PermissionError, handle_auth_error)
+```
+
+### `clear_global_error_handlers()`
+
+Removes all registered global error handlers. Useful in tests.
+
+---
+
+## Contract Testing
+
+### `contract_test(request_model, response_model)`
+
+Decorator for validating plain handler functions in tests without an `HttpRequest`.
+
+### `verify_contracts(function, test_data, request_model, response_model)`
+
+Calls a plain handler with `test_data` as keyword arguments and validates the inputs and output against the provided models.
+
+---
+
+See the [Usage guide](usage.md) for runnable examples, and [Architecture](architecture.md) for package ownership boundaries.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,9 +3,94 @@
 This library is intentionally small and composable.
 
 Key ideas:
+
 - Decorator-based validation entry points
 - Pydantic v2 models for parsing and validation
 - Minimal coupling to Azure Functions runtime
 - No global mutable state
 
 For design principles, see `DESIGN.md`.
+
+## Package Ownership
+
+`azure-functions-validation` and `azure-functions-openapi` are separate packages with complementary but distinct responsibilities. Neither should duplicate the other's logic.
+
+### What `azure-functions-validation` owns
+
+| Concern | Description |
+|---|---|
+| **Request parsing** | Body, query, path, header extraction from `HttpRequest` |
+| **Request validation** | Pydantic model validation for all request sources |
+| **Response validation** | Pydantic model validation and serialization for responses |
+| **Error payload shape** | The `{"detail": [{"loc": [...], "msg": "...", "type": "..."}]}` structure |
+| **Validation metadata** | Structured descriptions of what a handler validates (`metadata.py`) |
+
+The `metadata.py` module is the **canonical source** for validation contract data. Anything that wants to describe or document what a handler validates should consume these helpers rather than re-implementing the logic.
+
+### What `azure-functions-openapi` owns
+
+| Concern | Description |
+|---|---|
+| **OpenAPI document generation** | Assembling the full OpenAPI spec |
+| **Route documentation** | Documenting paths, methods, and parameters |
+| **Schema presentation** | Deciding how schemas appear in the OpenAPI document |
+| **Response documentation** | Documenting response codes and bodies in spec form |
+
+### What neither package owns
+
+- Azure Functions routing (`func.FunctionApp`, `@app.route`) — that stays with the Azure Functions SDK
+- Authentication and authorization logic
+- Business logic
+
+## Integration Pattern
+
+When a user wants both runtime validation and OpenAPI documentation, the data flow is:
+
+```
+azure-functions-validation (runtime)
+  └── metadata.py  ──exports──▶  azure-functions-openapi (docs)
+        │                               │
+        │  describe_validation_contract │  consumes metadata to build
+        │  get_request_contract_metadata│  OpenAPI paths/components
+        │  get_validation_error_contract│
+        └───────────────────────────────┘
+```
+
+`azure-functions-validation` produces structured metadata about its runtime contracts. `azure-functions-openapi` consumes that metadata to generate documentation. The packages stay decoupled — validation does not import openapi, and openapi does not re-implement validation logic.
+
+### Example: sharing metadata with openapi tooling
+
+```python
+from azure_functions_validation import describe_validation_contract
+from pydantic import BaseModel
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+    email: str
+
+
+class CreateUserResponse(BaseModel):
+    message: str
+
+
+# Produce a full contract description for use by documentation tooling
+contract = describe_validation_contract(
+    body=CreateUserRequest,
+    response_model=CreateUserResponse,
+)
+
+# contract["request"]  → request sources with schemas
+# contract["response"] → response schema
+# contract["errors"]["validation"] → 422 error shape and examples
+```
+
+The OpenAPI package can consume `contract` directly, without reimplementing any validation logic.
+
+### What to avoid
+
+| Anti-pattern | Why it is wrong |
+|---|---|
+| `azure-functions-openapi` re-implementing error schema logic | Duplicates the error payload contract; may drift from runtime behaviour |
+| `azure-functions-validation` importing OpenAPI-specific types | Creates an unwanted coupling in the wrong direction |
+| Generating validation error examples in multiple places | The canonical source is `get_validation_error_contract` in `metadata.py` |


### PR DESCRIPTION
## Summary

- Expands docs/architecture.md to explicitly document the ownership boundary between azure-functions-validation and azure-functions-openapi: what each package owns, what neither owns, and how they integrate via the metadata surface
- Rewrites docs/api.md with a full structured reference covering all public functions grouped by purpose (Decorator, Validation Metadata, OpenAPI Helpers, Error Handling, Contract Testing)
- Adds an integration pattern section and anti-pattern table to prevent future boundary violations