### PR TITLE
chore: release v0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.7] - 2026-03-21
+
 ### Added
 
 - Real Azure end-to-end test workflow (`e2e-azure.yml`) deploying to Consumption plan (`koreacentral`)
 - `docs/testing.md` — Real Azure E2E Tests section
+- Mermaid diagrams to architecture and README
 
 ### Changed
 
-- GitHub Actions versions upgraded to Node.js 24 compatible: `checkout@v6`, `setup-python@v6`, `upload-artifact@v7`, `azure/login@v2.3.0`
+- GitHub Actions versions upgraded to Node.js 24 compatible versions
+- Repository consistency fixes (AGENTS.md, .gitignore standardization)
 
 ### Fixed
 
-- `@validate_http` decorator `co_argcount` bug — Azure Functions worker now correctly recognizes decorated handlers (v0.5.3)
+- `@validate_http` decorator `co_argcount` bug — Azure Functions worker now correctly recognizes decorated handlers
+- Set `__signature__` on wrapper to hide `**_kw` from Azure Functions worker
+- Clear wrapper `__annotations__` to prevent `FunctionLoadError` on Azure
+
 ## [0.5.2] - 2026-03-15
 
 ### Added

--- a/src/azure_functions_validation/__init__.py
+++ b/src/azure_functions_validation/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "ErrorFormatter",
 ]
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -30,8 +30,8 @@ class TestAPISurface:
             "ErrorFormatter",
         }
 
-    def test_version_is_0_5_6(self) -> None:
-        assert azure_functions_validation.__version__ == "0.5.6"
+    def test_version_is_0_5_7(self) -> None:
+        assert azure_functions_validation.__version__ == "0.5.7"
 
     def test_validate_http_is_callable(self) -> None:
         assert callable(validate_http)


### PR DESCRIPTION
## Summary
- bump package version to 0.5.7
- update public API version test to 0.5.7
- promote Unreleased changelog notes into the 0.5.7 release section