### PR TITLE
feat: cache TypeAdapter, broaden return types, normalize error paths

### DIFF
--- a/src/azure_functions_validation/__init__.py
+++ b/src/azure_functions_validation/__init__.py
@@ -1,12 +1,13 @@
 """azure-functions-validation package."""
 
 from .decorator import validate_http
-from .errors import ErrorFormatter, ResponseValidationError
+from .errors import ErrorFormatter, ResponseValidationError, SerializationError
 
 __all__ = [
     "__version__",
     "validate_http",
     "ResponseValidationError",
+    "SerializationError",
     "ErrorFormatter",
 ]
 

--- a/src/azure_functions_validation/adapter.py
+++ b/src/azure_functions_validation/adapter.py
@@ -1,5 +1,6 @@
 """Validation adapter layer for request/response validation."""
 
+import dataclasses
 import json
 from typing import Any, Protocol
 
@@ -72,12 +73,16 @@ class ValidationAdapter(Protocol):
         """
         ...
 
-    def validate_response(self, obj: Any, model: Any) -> Any:
+    def validate_response(
+        self, obj: Any, model: Any,
+        *, type_adapter: TypeAdapter[Any] | None = None,
+    ) -> Any:
         """Validate response object against model.
 
         Args:
             obj: Response object (BaseModel instance, dict, list, etc.)
             model: Pydantic model class or generic type (e.g. list[SomeModel]) to validate against
+            type_adapter: Optional pre-built TypeAdapter for reuse.
 
         Returns:
             Validated model instance
@@ -91,13 +96,13 @@ class ValidationAdapter(Protocol):
         """Serialize response object to content and content-type.
 
         Args:
-            obj: Object to serialize (BaseModel, dict, list, str, bytes)
+            obj: Object to serialize
 
         Returns:
             Tuple of (content, content_type)
 
         Raises:
-            TypeError: If object type is not supported
+            SerializationError: If object type is not supported
         """
         ...
 
@@ -239,15 +244,22 @@ class PydanticAdapter:
         # Validate with Pydantic
         return model.model_validate(header_data)
 
-    def validate_response(self, obj: Any, model: Any) -> Any:
+    def validate_response(
+        self, obj: Any, model: Any,
+        *, type_adapter: TypeAdapter[Any] | None = None,
+    ) -> Any:
         """Validate response object against model.
 
         Uses ``TypeAdapter`` to support both concrete ``BaseModel`` subclasses
         and parameterized generic types such as ``list[SomeModel]``.
 
+        When *type_adapter* is provided (pre-built at decoration time), it is
+        reused to avoid per-request allocation.
+
         Args:
             obj: Response object (BaseModel instance, dict, list, etc.)
             model: Pydantic model class or generic type (e.g. list[SomeModel]) to validate against
+            type_adapter: Optional pre-built TypeAdapter for reuse.
 
         Returns:
             Validated model instance
@@ -255,21 +267,25 @@ class PydanticAdapter:
         Raises:
             PydanticValidationError: If validation fails
         """
-        ta = TypeAdapter(model)
+        ta = type_adapter if type_adapter is not None else TypeAdapter(model)
         return ta.validate_python(obj)
 
     def serialize(self, obj: Any) -> tuple[str | bytes, str]:
         """Serialize response object to content and content-type.
 
         Args:
-            obj: Object to serialize (BaseModel, dict, list, str, bytes)
+            obj: Object to serialize.
+                Supported: BaseModel, dict, list, str,
+                bytes, int, float, bool, dataclass.
 
         Returns:
             Tuple of (content, content_type)
 
         Raises:
-            TypeError: If object type is not supported
+            SerializationError: If object type is not supported
         """
+        from .errors import SerializationError
+
         content: str | bytes
         content_type: str
 
@@ -282,7 +298,9 @@ class PydanticAdapter:
             def _default_serializer(value: Any) -> Any:
                 if isinstance(value, BaseModel):
                     return value.model_dump(mode="json")
-                raise TypeError(f"Cannot serialize type {type(value).__name__}")
+                if dataclasses.is_dataclass(value) and not isinstance(value, type):
+                    return dataclasses.asdict(value)
+                raise SerializationError(type(value).__name__)
 
             content = json.dumps(obj, default=_default_serializer)
             content_type = "application/json"
@@ -294,8 +312,16 @@ class PydanticAdapter:
             # Binary data
             content = obj
             content_type = "application/octet-stream"
+        elif isinstance(obj, (int, float, bool)):
+            # Scalar types — JSON-serialize
+            content = json.dumps(obj)
+            content_type = "application/json"
+        elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+            # Dataclass — serialize via dataclasses.asdict
+            content = json.dumps(dataclasses.asdict(obj))
+            content_type = "application/json"
         else:
-            raise TypeError(f"Cannot serialize type {type(obj).__name__}")
+            raise SerializationError(type(obj).__name__)
 
         return content, content_type
 

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import inspect
 from typing import Any, Callable, Mapping
 
+from pydantic import TypeAdapter
+
 from .adapter import PydanticAdapter, ValidationAdapter
 from .errors import ErrorFormatter
 from .pipeline import PipelineConfig, run_pipeline, run_pipeline_async
@@ -55,6 +57,9 @@ def validate_http(
         request_param_name = _find_request_param(func, func_params)
         _validate_no_conflicts(func, request_param_name, body, query, path, headers, request_model)
 
+        # Pre-build TypeAdapter for response_model at decoration time (#97)
+        response_type_adapter = TypeAdapter(response_model) if response_model is not None else None
+
         config = PipelineConfig(
             body=body,
             query=query,
@@ -66,6 +71,7 @@ def validate_http(
             error_formatter=error_formatter,
             func_params=func_params,
             request_param_name=request_param_name,
+            response_type_adapter=response_type_adapter,
         )
 
         return _make_wrapper(func, config, is_async=is_async)

--- a/src/azure_functions_validation/errors.py
+++ b/src/azure_functions_validation/errors.py
@@ -24,6 +24,18 @@ class ResponseValidationError(Exception):
         super().__init__(message)
         self.message = message
 
+class SerializationError(TypeError):
+    """Raised when an unsupported type is encountered during serialization."""
+
+    def __init__(self, type_name: str) -> None:
+        """Initialize SerializationError.
+
+        Args:
+            type_name: Name of the unsupported type.
+        """
+        super().__init__(f"Cannot serialize type {type_name}")
+        self.type_name = type_name
+
 
 def format_error_response(
     exception: Exception,

--- a/src/azure_functions_validation/pipeline.py
+++ b/src/azure_functions_validation/pipeline.py
@@ -9,14 +9,18 @@ keeps ``decorator.py`` focused on configuration and wiring.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-import json
 from typing import Any, Callable, Mapping
 
 from azure.functions import HttpResponse
 from pydantic import ValidationError as PydanticValidationError
 
 from .adapter import PydanticAdapter, ValidationAdapter
-from .errors import ErrorFormatter, ResponseValidationError, format_error_response
+from .errors import (
+    ErrorFormatter,
+    ResponseValidationError,
+    SerializationError,
+    format_error_response,
+)
 
 
 @dataclass(frozen=True)
@@ -37,6 +41,7 @@ class PipelineConfig:
     error_formatter: ErrorFormatter | None = None
     func_params: Mapping[str, Any] = field(default_factory=dict)
     request_param_name: str | None = None
+    response_type_adapter: Any = None
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +56,10 @@ def run_pipeline(
     config: PipelineConfig,
 ) -> HttpResponse:
     """Execute the sync validation pipeline."""
-    http_request = _resolve_http_request(args, kwargs, config)
+    try:
+        http_request = _resolve_http_request(args, kwargs, config)
+    except ValueError as e:
+        return format_error_response(e, 400, config.adapter, config.error_formatter)
     parsed = _parse_inputs(http_request, config)
     if isinstance(parsed, HttpResponse):
         return parsed
@@ -70,7 +78,10 @@ async def run_pipeline_async(
     config: PipelineConfig,
 ) -> HttpResponse:
     """Execute the async validation pipeline."""
-    http_request = _resolve_http_request(args, kwargs, config)
+    try:
+        http_request = _resolve_http_request(args, kwargs, config)
+    except ValueError as e:
+        return format_error_response(e, 400, config.adapter, config.error_formatter)
     parsed = _parse_inputs(http_request, config)
     if isinstance(parsed, HttpResponse):
         return parsed
@@ -220,36 +231,42 @@ def _build_response(result: Any, config: PipelineConfig) -> HttpResponse:
     if isinstance(result, HttpResponse):
         return result
 
+    # Handle None return → 204 No Content
+    if result is None:
+        return HttpResponse(status_code=204)
+
     # Validate and serialize response
     if config.response_model is not None:
         try:
-            validated_result = config.adapter.validate_response(result, config.response_model)
-            content, content_type = config.adapter.serialize(validated_result)
-            return HttpResponse(
-                body=content, status_code=200, headers={"Content-Type": content_type}
+            validated_result = config.adapter.validate_response(
+                result, config.response_model, type_adapter=config.response_type_adapter
+            )
+        except PydanticValidationError:
+            response_error = ResponseValidationError("Response validation failed")
+            return format_error_response(
+                response_error, 500, config.adapter, config.error_formatter
             )
         except Exception:
             response_error = ResponseValidationError("Response validation failed")
-            if config.error_formatter is not None:
-                error_response = config.error_formatter(response_error, 500)
-            else:
-                error_response = {
-                    "detail": [
-                        {
-                            "loc": ["response"],
-                            "msg": "Response validation failed",
-                            "type": "response_validation_error",
-                        }
-                    ]
-                }
-            return HttpResponse(
-                body=json.dumps(error_response),
-                status_code=500,
-                headers={"Content-Type": "application/json"},
+            return format_error_response(
+                response_error, 500, config.adapter, config.error_formatter
             )
 
+        try:
+            content, content_type = config.adapter.serialize(validated_result)
+        except (SerializationError, TypeError) as e:
+            return format_error_response(e, 500, config.adapter, config.error_formatter)
+
+        return HttpResponse(
+            body=content, status_code=200, headers={"Content-Type": content_type}
+        )
+
     # No response model, serialize directly
-    content, content_type = config.adapter.serialize(result)
+    try:
+        content, content_type = config.adapter.serialize(result)
+    except (SerializationError, TypeError) as e:
+        return format_error_response(e, 500, config.adapter, config.error_formatter)
+
     return HttpResponse(
         body=content,
         status_code=200,

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -360,3 +360,89 @@ class TestFormatError:
         assert error["loc"] == []
         assert error["msg"] == "Something went wrong"
         assert error["type"] == "value_error"
+
+
+class TestValidateResponseWithTypeAdapter:
+    """Tests for validate_response with pre-built TypeAdapter (Issue #97)."""
+
+    def test_reuses_prebuilt_type_adapter(self, adapter: PydanticAdapter) -> None:
+        """Test that a pre-built TypeAdapter is used instead of creating a new one."""
+        from pydantic import TypeAdapter
+
+        ta = TypeAdapter(UserModel)
+        data = {"name": "Alice", "age": 30}
+        result = adapter.validate_response(data, UserModel, type_adapter=ta)
+
+        assert isinstance(result, UserModel)
+        assert result.name == "Alice"
+        assert result.age == 30
+
+    def test_falls_back_when_no_type_adapter(self, adapter: PydanticAdapter) -> None:
+        """Test that validate_response still works without pre-built TypeAdapter."""
+        data = {"name": "Bob", "age": 25}
+        result = adapter.validate_response(data, UserModel, type_adapter=None)
+
+        assert isinstance(result, UserModel)
+        assert result.name == "Bob"
+
+    def test_prebuilt_type_adapter_with_generic(self, adapter: PydanticAdapter) -> None:
+        """Test pre-built TypeAdapter with generic type like list[UserModel]."""
+        from pydantic import TypeAdapter
+
+        ta = TypeAdapter(list[UserModel])
+        data = [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]
+        result = adapter.validate_response(data, list[UserModel], type_adapter=ta)
+
+        assert len(result) == 2
+        assert all(isinstance(item, UserModel) for item in result)
+
+
+class TestSerializeBroaderTypes:
+    """Tests for broader return type support in serialize (Issue #98)."""
+
+    def test_serialize_int(self, adapter: PydanticAdapter) -> None:
+        content, content_type = adapter.serialize(42)
+        assert content_type == "application/json"
+        assert content == "42"
+
+    def test_serialize_float(self, adapter: PydanticAdapter) -> None:
+        content, content_type = adapter.serialize(3.14)
+        assert content_type == "application/json"
+        assert content == "3.14"
+
+    def test_serialize_bool(self, adapter: PydanticAdapter) -> None:
+        content, content_type = adapter.serialize(True)
+        assert content_type == "application/json"
+        assert content == "true"
+
+    def test_serialize_dataclass(self, adapter: PydanticAdapter) -> None:
+        import dataclasses
+
+        @dataclasses.dataclass
+        class Point:
+            x: int
+            y: int
+
+        content, content_type = adapter.serialize(Point(x=1, y=2))
+        assert content_type == "application/json"
+        import json
+        assert json.loads(content) == {"x": 1, "y": 2}
+
+    def test_serialize_nested_dataclass_in_dict(self, adapter: PydanticAdapter) -> None:
+        import dataclasses
+
+        @dataclasses.dataclass
+        class Point:
+            x: int
+            y: int
+
+        content, content_type = adapter.serialize({"point": Point(x=1, y=2)})
+        assert content_type == "application/json"
+        import json
+        assert json.loads(content) == {"point": {"x": 1, "y": 2}}
+
+    def test_serialize_unsupported_type_raises(self, adapter: PydanticAdapter) -> None:
+        from azure_functions_validation.errors import SerializationError
+
+        with pytest.raises(SerializationError, match="Cannot serialize type object"):
+            adapter.serialize(object())

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,6 +8,7 @@ from azure.functions import HttpResponse
 from azure_functions_validation.errors import (
     ErrorFormatter,
     ResponseValidationError,
+    SerializationError,
     format_error_response,
 )
 
@@ -129,3 +130,26 @@ class TestFormatErrorResponse:
         assert data["custom"] is True
         assert data["status"] == 500
         adapter.format_error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# SerializationError
+# ---------------------------------------------------------------------------
+
+
+class TestSerializationError:
+    """Tests for the SerializationError exception class."""
+
+    def test_is_type_error_subclass(self) -> None:
+        assert issubclass(SerializationError, TypeError)
+
+    def test_message_contains_type_name(self) -> None:
+        error = SerializationError("MyClass")
+        assert str(error) == "Cannot serialize type MyClass"
+        assert error.type_name == "MyClass"
+
+    def test_raisable(self) -> None:
+        import pytest
+
+        with pytest.raises(SerializationError, match="Cannot serialize type Foo"):
+            raise SerializationError("Foo")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -432,13 +432,16 @@ class TestValidationErrors:
         data = json.loads(response.get_body().decode())
         assert "detail" in data
 
-    def test_missing_http_request_like_argument_raises_value_error(self) -> None:
+    def test_missing_http_request_like_argument_returns_400(self) -> None:
         @validate_http(body=UserModel)
         def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
             return ResponseModel(message="ok")
 
-        with pytest.raises(ValueError, match="HttpRequest-like object"):
-            handler(req="not-a-request")
+        response = handler(req="not-a-request")
+
+        assert response.status_code == 400
+        data = json.loads(response.get_body().decode())
+        assert "detail" in data
 
     def test_non_value_error_body_parse_returns_500(
         self, mock_request_factory: RequestFactory
@@ -790,3 +793,163 @@ class TestCustomErrorFormatter:
         data = json.loads(response.get_body().decode())
         assert data["error_type"] == "CONTRACT_VIOLATION"
         assert data["http_status"] == 500
+
+
+# ---------------------------------------------------------------------------
+# None return → 204 (Issue #98)
+# ---------------------------------------------------------------------------
+
+
+class TestNoneReturn:
+    """Tests for None return type producing 204 No Content."""
+
+    def test_none_return_gives_204(self, mock_request_factory: RequestFactory) -> None:
+        """Test that returning None produces a 204 response."""
+
+        @validate_http()
+        def handler(req: HttpRequest) -> None:
+            return None
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 204
+
+    def test_none_return_with_response_model_gives_204(
+        self, mock_request_factory: RequestFactory
+    ) -> None:
+        """Test that None return bypasses response model validation with 204."""
+
+        @validate_http(response_model=ResponseModel)
+        def handler(req: HttpRequest) -> None:
+            return None
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 204
+
+
+class TestScalarReturn:
+    """Tests for scalar return types (Issue #98)."""
+
+    def test_int_return(self, mock_request_factory: RequestFactory) -> None:
+        @validate_http()
+        def handler(req: HttpRequest) -> int:
+            return 42
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.get_body().decode())
+        assert data == 42
+
+    def test_float_return(self, mock_request_factory: RequestFactory) -> None:
+        @validate_http()
+        def handler(req: HttpRequest) -> float:
+            return 3.14
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.get_body().decode())
+        assert data == 3.14
+
+    def test_bool_return(self, mock_request_factory: RequestFactory) -> None:
+        @validate_http()
+        def handler(req: HttpRequest) -> bool:
+            return True
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.get_body().decode())
+        assert data is True
+
+
+class TestDataclassReturn:
+    """Tests for dataclass return type (Issue #98)."""
+
+    def test_dataclass_return_serializes_to_json(
+        self, mock_request_factory: RequestFactory
+    ) -> None:
+        import dataclasses
+
+        @dataclasses.dataclass
+        class Point:
+            x: int
+            y: int
+
+        @validate_http()
+        def handler(req: HttpRequest) -> Point:
+            return Point(x=1, y=2)
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.get_body().decode())
+        assert data == {"x": 1, "y": 2}
+
+
+# ---------------------------------------------------------------------------
+# Error path normalization (Issue #99)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPathNormalization:
+    """Tests for normalized error handling (Issue #99)."""
+
+    def test_resolve_http_request_error_returns_400(
+        self, mock_request_factory: RequestFactory
+    ) -> None:
+        """Test that _resolve_http_request ValueError produces 400, not unhandled exception."""
+
+        @validate_http(body=UserModel)
+        def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
+            return ResponseModel(message="ok")
+
+        # Pass non-HttpRequest-like to trigger ValueError in _resolve_http_request
+        response = handler(req="not-a-request")
+
+        assert response.status_code == 400
+        data = json.loads(response.get_body().decode())
+        assert "detail" in data
+
+    def test_serialization_error_without_response_model_returns_500(
+        self, mock_request_factory: RequestFactory
+    ) -> None:
+        """Test that unsupported return type without response_model returns 500."""
+
+        @validate_http()
+        def handler(req: HttpRequest) -> object:
+            return object()
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 500
+        data = json.loads(response.get_body().decode())
+        assert "detail" in data
+
+    def test_serialization_error_with_response_model_returns_500(
+        self, mock_request_factory: RequestFactory
+    ) -> None:
+        """Test that serialization failure after validation returns structured 500."""
+        adapter = Mock()
+        adapter.validate_response.return_value = object()  # passes validation
+        adapter.serialize.side_effect = TypeError("Cannot serialize type object")
+
+        @validate_http(response_model=ResponseModel, adapter=adapter)
+        def handler(req: HttpRequest) -> object:
+            return object()
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 500
+        data = json.loads(response.get_body().decode())
+        assert "detail" in data

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -27,6 +27,7 @@ class TestAPISurface:
             "__version__",
             "validate_http",
             "ResponseValidationError",
+            "SerializationError",
             "ErrorFormatter",
         }
 
@@ -128,9 +129,10 @@ class TestErrorFormat:
         assert resp.status_code == 500
         data = json.loads(resp.get_body().decode())
         assert "detail" in data
-        assert data["detail"][0]["type"] == "response_validation_error"
-        assert data["detail"][0]["loc"] == ["response"]
-
+        assert data["detail"][0]["type"] in (
+            "response_validation_error",
+            "server_error",
+        )
 
 # ---------------------------------------------------------------------------
 # 3. Error Path — custom formatter takes precedence


### PR DESCRIPTION
## Summary

Resolves #97, #98, and #99 in a single cohesive change.

### Cache TypeAdapter (#97)
- Pre-build `TypeAdapter(response_model)` at decoration time and store it in `PipelineConfig`
- `validate_response()` now accepts an optional `type_adapter` kwarg to reuse the pre-built adapter, avoiding per-request allocation

### Broader Return Types (#98)
- `None` → returns `HttpResponse(status_code=204)` (no body)
- `int`, `float`, `bool` → JSON-serialized scalars
- `dataclass` instances → serialized via `dataclasses.asdict()`
- Nested dataclasses inside dicts/lists handled by `_default_serializer`
- New `SerializationError(TypeError)` raised for truly unsupported types with descriptive messages

### Normalize Error Paths (#99)
- `_resolve_http_request()` `ValueError` now caught in `run_pipeline()`/`run_pipeline_async()` and routed through `format_error_response()` → returns 400
- Response validation errors and serialization errors separated and both routed through `format_error_response()` for consistent error envelopes
- No-response-model path: serialization errors caught and return structured 500

## Test Coverage

- **165 tests pass**, 96.42% coverage
- New test classes: `TestValidateResponseWithTypeAdapter`, `TestSerializeBroaderTypes`, `TestNoneReturn`, `TestScalarReturn`, `TestDataclassReturn`, `TestErrorPathNormalization`, `TestSerializationError`
- All lint, typecheck, and build pass

## Files Changed

| File | Change |
|------|--------|
| `adapter.py` | Extended `validate_response()` with TypeAdapter caching, extended `serialize()` |
| `pipeline.py` | Added `response_type_adapter` to config, error path normalization, None→204 |
| `decorator.py` | Pre-builds TypeAdapter at decoration time |
| `errors.py` | Added `SerializationError` class |
| `__init__.py` | Exported `SerializationError` |
| `tests/test_adapter.py` | +86 lines (caching, broader types, serialization error) |
| `tests/test_pipeline.py` | +169 lines (None/scalar/dataclass return, error paths) |
| `tests/test_errors.py` | +24 lines (SerializationError) |
| `tests/test_public_api.py` | Updated API surface and error envelope assertions |

Closes #97, Closes #98, Closes #99