### PR TITLE
feat: cache TypeAdapter at decoration time (#97)

### DIFF
--- a/src/azure_functions_validation/adapter.py
+++ b/src/azure_functions_validation/adapter.py
@@ -72,12 +72,16 @@ class ValidationAdapter(Protocol):
         """
         ...
 
-    def validate_response(self, obj: Any, model: Any) -> Any:
+    def validate_response(
+        self, obj: Any, model: Any,
+        *, type_adapter: TypeAdapter[Any] | None = None,
+    ) -> Any:
         """Validate response object against model.
 
         Args:
             obj: Response object (BaseModel instance, dict, list, etc.)
             model: Pydantic model class or generic type (e.g. list[SomeModel]) to validate against
+            type_adapter: Optional pre-built TypeAdapter for reuse.
 
         Returns:
             Validated model instance
@@ -239,15 +243,22 @@ class PydanticAdapter:
         # Validate with Pydantic
         return model.model_validate(header_data)
 
-    def validate_response(self, obj: Any, model: Any) -> Any:
+    def validate_response(
+        self, obj: Any, model: Any,
+        *, type_adapter: TypeAdapter[Any] | None = None,
+    ) -> Any:
         """Validate response object against model.
 
         Uses ``TypeAdapter`` to support both concrete ``BaseModel`` subclasses
         and parameterized generic types such as ``list[SomeModel]``.
 
+        When *type_adapter* is provided (pre-built at decoration time), it is
+        reused to avoid per-request allocation.
+
         Args:
             obj: Response object (BaseModel instance, dict, list, etc.)
             model: Pydantic model class or generic type (e.g. list[SomeModel]) to validate against
+            type_adapter: Optional pre-built TypeAdapter for reuse.
 
         Returns:
             Validated model instance
@@ -255,7 +266,7 @@ class PydanticAdapter:
         Raises:
             PydanticValidationError: If validation fails
         """
-        ta = TypeAdapter(model)
+        ta = type_adapter if type_adapter is not None else TypeAdapter(model)
         return ta.validate_python(obj)
 
     def serialize(self, obj: Any) -> tuple[str | bytes, str]:

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import inspect
 from typing import Any, Callable, Mapping
 
+from pydantic import TypeAdapter
+
 from .adapter import PydanticAdapter, ValidationAdapter
 from .errors import ErrorFormatter
 from .pipeline import PipelineConfig, run_pipeline, run_pipeline_async
@@ -55,6 +57,9 @@ def validate_http(
         request_param_name = _find_request_param(func, func_params)
         _validate_no_conflicts(func, request_param_name, body, query, path, headers, request_model)
 
+        # Pre-build TypeAdapter for response_model at decoration time (#97)
+        response_type_adapter = TypeAdapter(response_model) if response_model is not None else None
+
         config = PipelineConfig(
             body=body,
             query=query,
@@ -66,6 +71,7 @@ def validate_http(
             error_formatter=error_formatter,
             func_params=func_params,
             request_param_name=request_param_name,
+            response_type_adapter=response_type_adapter,
         )
 
         return _make_wrapper(func, config, is_async=is_async)

--- a/src/azure_functions_validation/pipeline.py
+++ b/src/azure_functions_validation/pipeline.py
@@ -37,6 +37,7 @@ class PipelineConfig:
     error_formatter: ErrorFormatter | None = None
     func_params: Mapping[str, Any] = field(default_factory=dict)
     request_param_name: str | None = None
+    response_type_adapter: Any = None
 
 
 # ---------------------------------------------------------------------------
@@ -223,7 +224,9 @@ def _build_response(result: Any, config: PipelineConfig) -> HttpResponse:
     # Validate and serialize response
     if config.response_model is not None:
         try:
-            validated_result = config.adapter.validate_response(result, config.response_model)
+            validated_result = config.adapter.validate_response(
+                result, config.response_model, type_adapter=config.response_type_adapter
+            )
             content, content_type = config.adapter.serialize(validated_result)
             return HttpResponse(
                 body=content, status_code=200, headers={"Content-Type": content_type}

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -360,3 +360,42 @@ class TestFormatError:
         assert error["loc"] == []
         assert error["msg"] == "Something went wrong"
         assert error["type"] == "value_error"
+
+
+class TestValidateResponseWithTypeAdapter:
+    """Tests for validate_response with pre-built TypeAdapter (Issue #97)."""
+
+    def test_reuses_prebuilt_type_adapter(self, adapter: PydanticAdapter) -> None:
+        """Test that a pre-built TypeAdapter is used instead of creating a new one."""
+        from pydantic import TypeAdapter
+
+        ta = TypeAdapter(UserModel)
+        data = {"name": "Alice", "age": 30}
+        result = adapter.validate_response(data, UserModel, type_adapter=ta)
+
+        assert isinstance(result, UserModel)
+        assert result.name == "Alice"
+        assert result.age == 30
+
+    def test_falls_back_when_no_type_adapter(self, adapter: PydanticAdapter) -> None:
+        """Test that validate_response still works without pre-built TypeAdapter."""
+        data = {"name": "Bob", "age": 25}
+        result = adapter.validate_response(data, UserModel, type_adapter=None)
+
+        assert isinstance(result, UserModel)
+        assert result.name == "Bob"
+
+    def test_prebuilt_type_adapter_with_generic(
+        self, adapter: PydanticAdapter,
+    ) -> None:
+        """Test pre-built TypeAdapter with generic type like list[UserModel]."""
+        from pydantic import TypeAdapter
+
+        ta = TypeAdapter(list[UserModel])
+        data = [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]
+        result = adapter.validate_response(
+            data, list[UserModel], type_adapter=ta,
+        )
+
+        assert len(result) == 2
+        assert all(isinstance(item, UserModel) for item in result)


### PR DESCRIPTION
## Summary

Pre-build `TypeAdapter(response_model)` once at decoration time and reuse it on every request, eliminating per-request `TypeAdapter` construction overhead.

Closes #97

## Changes

- **adapter.py**: Add `type_adapter` kwarg to `ValidationAdapter.validate_response` protocol and `PydanticAdapter` implementation. When provided, the pre-built adapter is reused; otherwise falls back to creating one on the fly.
- **decorator.py**: Pre-build `TypeAdapter(response_model)` in the `validate_http` decorator when `response_model` is set.
- **pipeline.py**: Add `response_type_adapter` field to `PipelineConfig`; pass it through in `_build_response`.
- **tests/test_adapter.py**: Add `TestValidateResponseWithTypeAdapter` (3 tests): pre-built reuse, None fallback, generic type support.

## Verification

- `make lint` ✅
- `make typecheck` ✅
- `make test` — 147 passed, 97.49% coverage ✅