### PR TITLE
feat: support broader return types in response serialization (#98)

### DIFF
--- a/src/azure_functions_validation/__init__.py
+++ b/src/azure_functions_validation/__init__.py
@@ -1,12 +1,13 @@
 """azure-functions-validation package."""
 
 from .decorator import validate_http
-from .errors import ErrorFormatter, ResponseValidationError
+from .errors import ErrorFormatter, ResponseValidationError, SerializationError
 
 __all__ = [
     "__version__",
     "validate_http",
     "ResponseValidationError",
+    "SerializationError",
     "ErrorFormatter",
 ]
 

--- a/src/azure_functions_validation/adapter.py
+++ b/src/azure_functions_validation/adapter.py
@@ -1,5 +1,6 @@
 """Validation adapter layer for request/response validation."""
 
+import dataclasses
 import json
 from typing import Any, Protocol
 
@@ -95,13 +96,13 @@ class ValidationAdapter(Protocol):
         """Serialize response object to content and content-type.
 
         Args:
-            obj: Object to serialize (BaseModel, dict, list, str, bytes)
+            obj: Object to serialize
 
         Returns:
             Tuple of (content, content_type)
 
         Raises:
-            TypeError: If object type is not supported
+            SerializationError: If object type is not supported
         """
         ...
 
@@ -273,14 +274,18 @@ class PydanticAdapter:
         """Serialize response object to content and content-type.
 
         Args:
-            obj: Object to serialize (BaseModel, dict, list, str, bytes)
+            obj: Object to serialize.
+                Supported: BaseModel, dict, list, str,
+                bytes, int, float, bool, dataclass.
 
         Returns:
             Tuple of (content, content_type)
 
         Raises:
-            TypeError: If object type is not supported
+            SerializationError: If object type is not supported
         """
+        from .errors import SerializationError
+
         content: str | bytes
         content_type: str
 
@@ -293,7 +298,9 @@ class PydanticAdapter:
             def _default_serializer(value: Any) -> Any:
                 if isinstance(value, BaseModel):
                     return value.model_dump(mode="json")
-                raise TypeError(f"Cannot serialize type {type(value).__name__}")
+                if dataclasses.is_dataclass(value) and not isinstance(value, type):
+                    return dataclasses.asdict(value)
+                raise SerializationError(type(value).__name__)
 
             content = json.dumps(obj, default=_default_serializer)
             content_type = "application/json"
@@ -305,8 +312,16 @@ class PydanticAdapter:
             # Binary data
             content = obj
             content_type = "application/octet-stream"
+        elif isinstance(obj, (int, float, bool)):
+            # Scalar types — JSON-serialize
+            content = json.dumps(obj)
+            content_type = "application/json"
+        elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+            # Dataclass — serialize via dataclasses.asdict
+            content = json.dumps(dataclasses.asdict(obj))
+            content_type = "application/json"
         else:
-            raise TypeError(f"Cannot serialize type {type(obj).__name__}")
+            raise SerializationError(type(obj).__name__)
 
         return content, content_type
 

--- a/src/azure_functions_validation/errors.py
+++ b/src/azure_functions_validation/errors.py
@@ -25,6 +25,19 @@ class ResponseValidationError(Exception):
         self.message = message
 
 
+class SerializationError(TypeError):
+    """Raised when an unsupported type is encountered during serialization."""
+
+    def __init__(self, type_name: str) -> None:
+        """Initialize SerializationError.
+
+        Args:
+            type_name: Name of the unsupported type.
+        """
+        super().__init__(f"Cannot serialize type {type_name}")
+        self.type_name = type_name
+
+
 def format_error_response(
     exception: Exception,
     status_code: int,

--- a/src/azure_functions_validation/pipeline.py
+++ b/src/azure_functions_validation/pipeline.py
@@ -221,6 +221,10 @@ def _build_response(result: Any, config: PipelineConfig) -> HttpResponse:
     if isinstance(result, HttpResponse):
         return result
 
+    # Handle None return → 204 No Content
+    if result is None:
+        return HttpResponse(status_code=204)
+
     # Validate and serialize response
     if config.response_model is not None:
         try:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -399,3 +399,58 @@ class TestValidateResponseWithTypeAdapter:
 
         assert len(result) == 2
         assert all(isinstance(item, UserModel) for item in result)
+
+
+class TestSerializeBroaderTypes:
+    """Tests for broader return type support in serialize (Issue #98)."""
+
+    def test_serialize_int(self, adapter: PydanticAdapter) -> None:
+        content, content_type = adapter.serialize(42)
+        assert content_type == "application/json"
+        assert content == "42"
+
+    def test_serialize_float(self, adapter: PydanticAdapter) -> None:
+        content, content_type = adapter.serialize(3.14)
+        assert content_type == "application/json"
+        assert content == "3.14"
+
+    def test_serialize_bool(self, adapter: PydanticAdapter) -> None:
+        content, content_type = adapter.serialize(True)
+        assert content_type == "application/json"
+        assert content == "true"
+
+    def test_serialize_dataclass(self, adapter: PydanticAdapter) -> None:
+        import dataclasses
+
+        @dataclasses.dataclass
+        class Point:
+            x: int
+            y: int
+
+        content, content_type = adapter.serialize(Point(x=1, y=2))
+        assert content_type == "application/json"
+        import json
+        assert json.loads(content) == {"x": 1, "y": 2}
+
+    def test_serialize_nested_dataclass_in_dict(
+        self, adapter: PydanticAdapter,
+    ) -> None:
+        import dataclasses
+
+        @dataclasses.dataclass
+        class Point:
+            x: int
+            y: int
+
+        content, content_type = adapter.serialize({"point": Point(x=1, y=2)})
+        assert content_type == "application/json"
+        import json
+        assert json.loads(content) == {"point": {"x": 1, "y": 2}}
+
+    def test_serialize_unsupported_type_raises(
+        self, adapter: PydanticAdapter,
+    ) -> None:
+        from azure_functions_validation.errors import SerializationError
+
+        with pytest.raises(SerializationError, match="Cannot serialize type object"):
+            adapter.serialize(object())

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,6 +8,7 @@ from azure.functions import HttpResponse
 from azure_functions_validation.errors import (
     ErrorFormatter,
     ResponseValidationError,
+    SerializationError,
     format_error_response,
 )
 
@@ -129,3 +130,26 @@ class TestFormatErrorResponse:
         assert data["custom"] is True
         assert data["status"] == 500
         adapter.format_error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# SerializationError
+# ---------------------------------------------------------------------------
+
+
+class TestSerializationError:
+    """Tests for the SerializationError exception class."""
+
+    def test_is_type_error_subclass(self) -> None:
+        assert issubclass(SerializationError, TypeError)
+
+    def test_message_contains_type_name(self) -> None:
+        error = SerializationError("MyClass")
+        assert str(error) == "Cannot serialize type MyClass"
+        assert error.type_name == "MyClass"
+
+    def test_raisable(self) -> None:
+        import pytest
+
+        with pytest.raises(SerializationError, match="Cannot serialize type Foo"):
+            raise SerializationError("Foo")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -790,3 +790,109 @@ class TestCustomErrorFormatter:
         data = json.loads(response.get_body().decode())
         assert data["error_type"] == "CONTRACT_VIOLATION"
         assert data["http_status"] == 500
+
+
+# ---------------------------------------------------------------------------
+# None return → 204 (Issue #98)
+# ---------------------------------------------------------------------------
+
+
+class TestNoneReturn:
+    """Tests for None return type producing 204 No Content."""
+
+    def test_none_return_gives_204(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        """Test that returning None produces a 204 response."""
+
+        @validate_http()
+        def handler(req: HttpRequest) -> None:
+            return None
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 204
+
+    def test_none_return_with_response_model_gives_204(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        """Test that None return bypasses response model validation with 204."""
+
+        @validate_http(response_model=ResponseModel)
+        def handler(req: HttpRequest) -> None:
+            return None
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 204
+
+
+class TestScalarReturn:
+    """Tests for scalar return types (Issue #98)."""
+
+    def test_int_return(self, mock_request_factory: RequestFactory) -> None:
+        @validate_http()
+        def handler(req: HttpRequest) -> int:
+            return 42
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.get_body().decode())
+        assert data == 42
+
+    def test_float_return(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        @validate_http()
+        def handler(req: HttpRequest) -> float:
+            return 3.14
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.get_body().decode())
+        assert data == 3.14
+
+    def test_bool_return(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        @validate_http()
+        def handler(req: HttpRequest) -> bool:
+            return True
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.get_body().decode())
+        assert data is True
+
+
+class TestDataclassReturn:
+    """Tests for dataclass return type (Issue #98)."""
+
+    def test_dataclass_return_serializes_to_json(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        import dataclasses
+
+        @dataclasses.dataclass
+        class Point:
+            x: int
+            y: int
+
+        @validate_http()
+        def handler(req: HttpRequest) -> Point:
+            return Point(x=1, y=2)
+
+        request = mock_request_factory()
+        response = handler(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.get_body().decode())
+        assert data == {"x": 1, "y": 2}

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -27,6 +27,7 @@ class TestAPISurface:
             "__version__",
             "validate_http",
             "ResponseValidationError",
+            "SerializationError",
             "ErrorFormatter",
         }
 


### PR DESCRIPTION
## Summary

Extend `serialize()` to handle `None`, scalar, and dataclass return types. Adds `SerializationError` for unsupported types.

Closes #98

## Changes

### Source
- **errors.py**: Add `SerializationError(TypeError)` with descriptive messages
- **`__init__.py`**: Export `SerializationError`
- **adapter.py**: 
  - Protocol docstring updated (`SerializationError` replaces `TypeError`)
  - `PydanticAdapter.serialize()` extended with `int`, `float`, `bool`, dataclass support
  - Nested dataclasses in dicts/lists handled via `_default_serializer`
  - `TypeError` → `SerializationError` for unsupported types
- **pipeline.py**: `None` return → `HttpResponse(status_code=204)` before response model check

### Tests
- **test_adapter.py**: `TestSerializeBroaderTypes` (6 tests) — int, float, bool, dataclass, nested dataclass, unsupported type
- **test_errors.py**: `TestSerializationError` (3 tests) — subclass check, message, raisability
- **test_pipeline.py**: `TestNoneReturn` (2 tests), `TestScalarReturn` (3 tests), `TestDataclassReturn` (1 test)
- **test_public_api.py**: Updated `test_all_exports` to include `SerializationError`

## Verification

- `make lint` ✅
- `make typecheck` ✅
- `make test` — 159 passed, 97.63% coverage ✅