### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-03-29
+
+### Added
+
+- Normalize error paths in validation pipeline (#104)
+- Support broader return types in response serialization (#102)
+- Cache TypeAdapter at decoration time to avoid per-request allocation (#101)
+- Docs-runtime sync verification tests for README examples (#110)
+- Golden snapshot tests for error response shapes (400/422/500) (#109)
+
+### Internal
+
+- Update README with Azure Functions Python DX Toolkit branding
+- Rename publish environment from production to release
+- Rename release.yml to publish-pypi.yml
+
 ## [0.5.7] - 2026-03-21
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,24 @@ The v0.5.0 release significantly reduced the public API surface to focus on the 
 
 ## Full Version History
 
+### v0.6.0 (2026-03-29)
+
+#### Features
+
+- Normalize error paths in validation pipeline (#104)
+- Support broader return types in response serialization (#102)
+- Cache TypeAdapter at decoration time to avoid per-request allocation (#101)
+
+#### Tests
+
+- Docs-runtime sync verification tests for README examples (#110)
+- Golden snapshot tests for error response shapes (400/422/500) (#109)
+
+#### Internal
+
+- Update README with Azure Functions Python DX Toolkit branding
+- CI/CD workflow unification
+
 ### v0.5.1 (2026-03-14)
 
 #### Changed

--- a/src/azure_functions_validation/__init__.py
+++ b/src/azure_functions_validation/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "ErrorFormatter",
 ]
 
-__version__ = "0.5.7"
+__version__ = "0.6.0"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -31,8 +31,8 @@ class TestAPISurface:
             "ErrorFormatter",
         }
 
-    def test_version_is_0_5_7(self) -> None:
-        assert azure_functions_validation.__version__ == "0.5.7"
+    def test_version_is_0_6_0(self) -> None:
+        assert azure_functions_validation.__version__ == "0.6.0"
 
     def test_validate_http_is_callable(self) -> None:
         assert callable(validate_http)


### PR DESCRIPTION
## Summary
- Bump version to 0.6.0
- Normalize error paths in validation pipeline (#104)
- Support broader return types in response serialization (#102)
- Cache TypeAdapter at decoration time (#101)
- Golden snapshot tests and docs-runtime sync verification