### PR TITLE
fix: use public pydantic API for missing request body errors

### DIFF
--- a/src/azure_functions_validation/adapter.py
+++ b/src/azure_functions_validation/adapter.py
@@ -121,6 +121,18 @@ class ValidationAdapter(Protocol):
 class PydanticAdapter:
     """Concrete validation adapter implementation using Pydantic v2."""
 
+    @staticmethod
+    def _missing_body_validation_error() -> PydanticValidationError:
+        class _MissingBodyPayload(BaseModel):
+            body: Any
+
+        try:
+            _MissingBodyPayload.model_validate({})
+        except PydanticValidationError as exc:
+            return exc
+
+        raise RuntimeError("Unreachable: expected missing body validation error")
+
     def parse_body(self, req: HttpRequest, model: type[BaseModel]) -> Any:
         """Parse and validate request body from JSON.
 
@@ -139,16 +151,7 @@ class PydanticAdapter:
 
         # Handle empty body
         if not body:
-            raise PydanticValidationError.from_exception_data(
-                "ValidationError",
-                [
-                    {
-                        "type": "missing",
-                        "loc": ("body",),
-                        "input": None,
-                    }
-                ],
-            )
+            raise self._missing_body_validation_error()
 
         # Parse JSON
         try:
@@ -158,16 +161,7 @@ class PydanticAdapter:
 
         if not body_str.strip():
             # Empty JSON string - this is a missing body, not invalid JSON
-            raise PydanticValidationError.from_exception_data(
-                "ValidationError",
-                [
-                    {
-                        "type": "missing",
-                        "loc": ("body",),
-                        "input": None,
-                    }
-                ],
-            )
+            raise self._missing_body_validation_error()
 
         try:
             data = json.loads(body_str)

--- a/src/azure_functions_validation/errors.py
+++ b/src/azure_functions_validation/errors.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Callable
+from typing import Any, Callable, Protocol
 
 from azure.functions import HttpResponse
 
-from .adapter import ValidationAdapter
-
 ErrorFormatter = Callable[[Exception, int], dict[str, Any]]
+
+
+class ErrorAdapter(Protocol):
+    def format_error(self, exc: Exception) -> dict[str, Any]: ...
 
 
 class ResponseValidationError(Exception):
@@ -41,7 +43,7 @@ class SerializationError(TypeError):
 def format_error_response(
     exception: Exception,
     status_code: int,
-    adapter: ValidationAdapter,
+    adapter: ErrorAdapter,
     error_formatter: ErrorFormatter | None = None,
 ) -> HttpResponse:
     """Build an ``HttpResponse`` for a validation or parsing error.

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -175,6 +175,21 @@ class TestGoldenErrorShapes:
         for detail in data["detail"]:
             assert set(detail.keys()) == {"loc", "msg", "type"}
 
+    @pytest.mark.parametrize("payload", [b"", b"   "])
+    def test_golden_422_missing_body_shape(self, payload: bytes) -> None:
+        @validate_http(body=BodyModel)
+        def handler(req: HttpRequest, body: BodyModel) -> dict[str, object]:
+            return {"ok": True}
+
+        resp = handler(_make_request(payload))
+        assert resp.status_code == 422
+
+        data = json.loads(resp.get_body().decode())
+        detail = data["detail"][0]
+        assert set(detail.keys()) == {"loc", "msg", "type"}
+        assert detail["loc"] == ["body"]
+        assert detail["type"] == "missing"
+
     def test_golden_500_server_error_shape(self) -> None:
         """500 response validation errors must have sanitized shape."""
         @validate_http(body=BodyModel, response_model=RespModel)


### PR DESCRIPTION
## Summary
- remove `PydanticValidationError.from_exception_data` usage from request body parsing
- preserve 422 missing-body behavior using a public Pydantic validation path

## Changes
- added a private helper in `PydanticAdapter` that creates a missing-body `ValidationError` via `BaseModel.model_validate`
- updated `parse_body` to use that helper for empty and whitespace-only bodies
- added a golden test to verify missing-body 422 responses keep the expected `detail` shape for both empty and whitespace payloads
- introduced a local protocol for `format_error_response` adapter typing to avoid runtime adapter/errors import cycles

## Validation
- `python -m pytest --no-cov -x -q`
- `python -m ruff check src/ tests/`
- `python -m mypy src/`

Closes #116