### PR TITLE
docs: add architecture diagram, MS Learn sources, and cross-repo See Also links

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -64,3 +64,44 @@ The v0.5.0 pipeline separation addressed the core structural concerns:
 
 - evaluate whether `PipelineConfig` fields should be exposed as a public API for tooling consumers
 - keep examples and smoke tests aligned with the runtime contract
+
+## High-Level Architecture
+
+```mermaid
+flowchart TD
+    subgraph import ["Import Time"]
+        DEC["@validate_http\ndecorator.py"]
+        PC["PipelineConfig\npipeline.py"]
+        DEC -- "builds once" --> PC
+    end
+
+    subgraph request ["Per-Request"]
+        PL["run_pipeline()\nrun_pipeline_async()"]
+        AD["PydanticAdapter\nadapter.py"]
+        H["Handler"]
+        ERR["errors.py\nformat_error_response()"]
+
+        PL -- "parse & validate\nrequest" --> AD
+        AD -- "typed args" --> PL
+        PL -- "invoke" --> H
+        H -- "return value" --> PL
+        PL -- "validate response" --> AD
+        PL -- "on error" --> ERR
+    end
+
+    PC -. "cached config" .-> PL
+```
+
+## Sources
+
+- [Azure Functions Python developer reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Azure Functions HTTP trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger)
+- [Supported languages in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+
+## See Also
+
+- [azure-functions-openapi — Architecture](https://github.com/yeongseon/azure-functions-openapi) — OpenAPI spec generation
+- [azure-functions-logging — Architecture](https://github.com/yeongseon/azure-functions-logging) — Structured logging with contextvars
+- [azure-functions-doctor — Architecture](https://github.com/yeongseon/azure-functions-doctor) — Pre-deploy diagnostic CLI
+- [azure-functions-scaffold — Architecture](https://github.com/yeongseon/azure-functions-scaffold) — Project scaffolding CLI
+- [azure-functions-langgraph — Architecture](https://github.com/yeongseon/azure-functions-langgraph) — LangGraph agent deployment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,3 +169,17 @@ flowchart LR
 - [Configuration](configuration.md)
 - [API Reference](api.md)
 - [Troubleshooting](troubleshooting.md)
+
+## Sources
+
+- [Azure Functions Python developer reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Azure Functions HTTP trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger)
+- [Supported languages in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+
+## See Also
+
+- [azure-functions-openapi — Architecture](https://github.com/yeongseon/azure-functions-openapi) — OpenAPI spec generation
+- [azure-functions-logging — Architecture](https://github.com/yeongseon/azure-functions-logging) — Structured logging with contextvars
+- [azure-functions-doctor — Architecture](https://github.com/yeongseon/azure-functions-doctor) — Pre-deploy diagnostic CLI
+- [azure-functions-scaffold — Architecture](https://github.com/yeongseon/azure-functions-scaffold) — Project scaffolding CLI
+- [azure-functions-langgraph — Architecture](https://github.com/yeongseon/azure-functions-langgraph) — LangGraph agent deployment


### PR DESCRIPTION
## Summary
- Add two-phase Mermaid flowchart to `DESIGN.md` showing import-time config creation (`@validate_http` → `PipelineConfig`) and per-request pipeline execution (`run_pipeline()` → `PydanticAdapter` → Handler → response validation)
- Add `## Sources` section with MS Learn references to both `DESIGN.md` and `docs/architecture.md`
- Add `## See Also` section with cross-repo architecture links to both files
- Keep existing "Related pages" section in `docs/architecture.md` as-is (internal doc navigation)

## Oracle Reviews
- **Design review**: Recommended two-phase diagram (import-time vs per-request), not showing decorator calling adapter directly — applied
- **Post-impl review**: Approved additions. Noted pre-existing inaccuracy in existing sequence diagram (error handling flow) — out of scope for this PR

## Verification
- `make check-all` passes: all tests pass, lint/type/security clean

Closes #123