### PR TITLE
docs: pin Mermaid JS version and add site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Azure Functions Validation
 site_description: Validation and serialization for Python-based Azure Functions
 site_author: Yeongseon Choe
+site_url: https://yeongseon.github.io/azure-functions-validation/
 repo_url: https://github.com/yeongseon/azure-functions-validation
 edit_uri: edit/main/docs/
 
@@ -75,4 +76,4 @@ extra:
     © 2026 Yeongseon Choe – MIT Licensed
 
 extra_javascript:
-  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+  - https://unpkg.com/mermaid@11.14.0/dist/mermaid.min.js


### PR DESCRIPTION
## Summary

- Pin Mermaid CDN from floating `@11` to exact `@11.14.0` for reproducible builds
- Add `site_url` for canonical URLs and sitemap generation

## Changes

**`mkdocs.yml`**: 
- `https://unpkg.com/mermaid@11/dist/mermaid.min.js` → `https://unpkg.com/mermaid@11.14.0/dist/mermaid.min.js`
- Added `site_url: https://yeongseon.github.io/azure-functions-validation/`

## Context

Part of cross-repo mkdocs.yml standardization. All 6 azure-functions repos now use identical Mermaid configuration.

## Validation

- `make check-all` passes

Fixes #128