### PR TITLE
feat: expose ValidationMetadata for OpenAPI bridge integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,131 @@ Azure Functions Python v2 handlers often drift into the same repeated problems:
 - **Response model enforcement** — mismatches raise `ResponseValidationError` (HTTP 500)
 - **Decorator-first API** — `@validate_http` wraps your handler, no boilerplate needed
 
+## Before / After
+
+**Without** this package — manual parsing, manual errors, no contracts:
+
+```python
+import json
+import azure.functions as func
+
+app = func.FunctionApp()
+
+
+@app.route(route="users", methods=["POST"])
+def create_user(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        body = req.get_json()
+    except ValueError:
+        return func.HttpResponse(
+            json.dumps({"error": "Invalid JSON"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    name = body.get("name")
+    email = body.get("email")
+    if not name or not isinstance(name, str):
+        return func.HttpResponse(
+            json.dumps({"error": "name is required"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+    if not email or not isinstance(email, str):
+        return func.HttpResponse(
+            json.dumps({"error": "email is required"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    return func.HttpResponse(
+        json.dumps({"message": f"Hello {name}", "status": "success"}),
+        mimetype="application/json",
+    )
+```
+
+**With** `@validate_http` — typed, consistent, contract-enforced:
+
+```python
+import azure.functions as func
+from pydantic import BaseModel
+
+from azure_functions_validation import validate_http
+
+app = func.FunctionApp()
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+    email: str
+
+
+class CreateUserResponse(BaseModel):
+    message: str
+    status: str = "success"
+
+
+@app.route(route="users", methods=["POST"])
+@validate_http(body=CreateUserRequest, response_model=CreateUserResponse)
+def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserResponse:
+    return CreateUserResponse(message=f"Hello {body.name}")
+```
+
+> **30 lines → 10 lines.** Validation, error formatting, and response contracts — handled.
+
+### What you get
+
+**Valid request** → typed response:
+
+```bash
+$ curl -s -X POST http://localhost:7071/api/users \
+    -H "Content-Type: application/json" \
+    -d '{"name": "Alice", "email": "alice@example.com"}'
+```
+
+```json
+{"message": "Hello Alice", "status": "success"}
+```
+
+> HTTP 200
+
+**Missing required field** → automatic Pydantic v2 error:
+
+```bash
+$ curl -s -X POST http://localhost:7071/api/users \
+    -H "Content-Type: application/json" \
+    -d '{"name": "Alice"}'
+```
+
+```json
+{
+  "detail": [
+    {
+      "type": "missing",
+      "loc": ["body", "email"],
+      "msg": "Field required",
+      "input": {"name": "Alice"}
+    }
+  ]
+}
+```
+
+> HTTP 422 — Pydantic v2 error format, automatic
+
+**Invalid JSON** → clear error:
+
+```bash
+$ curl -s -X POST http://localhost:7071/api/users \
+    -H "Content-Type: application/json" \
+    -d 'not json'
+```
+
+```json
+{"detail": [{"loc": [], "msg": "Invalid JSON", "type": "value_error"}]}
+```
+
+> HTTP 400
+
 ## FastAPI comparison
 
 | Feature | FastAPI | azure-functions-validation |

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserRes
     return CreateUserResponse(message=f"Hello {body.name}")
 ```
 
-> **30 lines → 10 lines.** Validation, error formatting, and response contracts — handled.
+> Manual parsing and validation disappear from the handler. Error formatting and response contracts — handled.
 
 ### What you get
 
@@ -123,7 +123,7 @@ $ curl -s -X POST http://localhost:7071/api/users \
 
 > HTTP 200
 
-**Missing required field** → automatic Pydantic v2 error:
+**Missing required field** → automatic error response:
 
 ```bash
 $ curl -s -X POST http://localhost:7071/api/users \
@@ -135,16 +135,15 @@ $ curl -s -X POST http://localhost:7071/api/users \
 {
   "detail": [
     {
-      "type": "missing",
-      "loc": ["body", "email"],
+      "loc": ["email"],
       "msg": "Field required",
-      "input": {"name": "Alice"}
+      "type": "missing"
     }
   ]
 }
 ```
 
-> HTTP 422 — Pydantic v2 error format, automatic
+> HTTP 422 — standardized error response, automatic
 
 **Invalid JSON** → clear error:
 

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -21,11 +21,11 @@ class ValidationMetadata:
     discover Pydantic models attached to validated handlers.
     """
 
-    body: Any = None
-    query: Any = None
-    path: Any = None
-    headers: Any = None
-    response_model: Any = None
+    body: Any | None = None
+    query: Any | None = None
+    path: Any | None = None
+    headers: Any | None = None
+    response_model: Any | None = None
 
 
 def validate_http(
@@ -90,7 +90,19 @@ def validate_http(
             response_type_adapter=response_type_adapter,
         )
 
-        return _make_wrapper(func, config, is_async=is_async)
+        wrapper = _make_wrapper(func, config, is_async=is_async)
+        setattr(
+            wrapper,
+            "_af_validation_metadata",
+            ValidationMetadata(
+                body=body,
+                query=query,
+                path=path,
+                headers=headers,
+                response_model=response_model,
+            ),
+        )
+        return wrapper
 
     return decorator
 
@@ -273,18 +285,4 @@ def get_validation_metadata(func: Any) -> ValidationMetadata | None:
 
     Returns None if the function has no validation metadata attached.
     """
-    # Try convention attribute first.
-    toolkit_meta = getattr(func, "_azure_functions_toolkit_metadata", None)
-    if isinstance(toolkit_meta, dict):
-        hints = toolkit_meta.get("validation")
-        if isinstance(hints, dict):
-            return ValidationMetadata(
-                body=hints.get("body"),
-                query=hints.get("query"),
-                path=hints.get("path"),
-                headers=hints.get("headers"),
-                response_model=hints.get("response_model"),
-            )
-
-    # Legacy fallback.
     return getattr(func, "_af_validation_metadata", None)

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -281,8 +281,20 @@ def get_validation_metadata(func: Any) -> ValidationMetadata | None:
     """Return validation metadata if the function was decorated with @validate_http.
 
     Checks the convention-based ``_azure_functions_toolkit_metadata`` attribute
-    first, then falls back to the legacy ``_af_validation_metadata`` attribute.
+    first and converts it to a :class:`ValidationMetadata` instance.  Falls back
+    to the legacy ``_af_validation_metadata`` attribute for backward compatibility.
 
     Returns None if the function has no validation metadata attached.
     """
+    toolkit_meta = getattr(func, "_azure_functions_toolkit_metadata", None)
+    if toolkit_meta is not None:
+        validation_ns = toolkit_meta.get("validation")
+        if validation_ns is not None:
+            return ValidationMetadata(
+                body=validation_ns.get("body"),
+                query=validation_ns.get("query"),
+                path=validation_ns.get("path"),
+                headers=validation_ns.get("headers"),
+                response_model=validation_ns.get("response_model"),
+            )
     return getattr(func, "_af_validation_metadata", None)

--- a/tests/test_toolkit_metadata.py
+++ b/tests/test_toolkit_metadata.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel
 
 from azure_functions_validation import ValidationMetadata, get_validation_metadata, validate_http
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_validation_metadata.py
+++ b/tests/test_validation_metadata.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+from azure.functions import HttpRequest
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_validation import get_validation_metadata, validate_http
+
+
+class BodyModel(BaseModel):
+    name: str
+
+
+class QueryModel(BaseModel):
+    page: int = 1
+
+
+class PathModel(BaseModel):
+    item_id: str
+
+
+class HeaderModel(BaseModel):
+    x_request_id: str
+
+
+class ResponseModel(BaseModel):
+    ok: bool
+
+
+def test_metadata_discoverable_on_decorated_function() -> None:
+    @validate_http(
+        body=BodyModel,
+        query=QueryModel,
+        path=PathModel,
+        headers=HeaderModel,
+        response_model=ResponseModel,
+    )
+    def handler(
+        req: HttpRequest,
+        body: BodyModel,
+        query: QueryModel,
+        path: PathModel,
+        headers: HeaderModel,
+    ) -> ResponseModel:
+        return ResponseModel(ok=True)
+
+    metadata = get_validation_metadata(handler)
+    assert metadata is not None
+    assert metadata.body is BodyModel
+    assert metadata.query is QueryModel
+    assert metadata.path is PathModel
+    assert metadata.headers is HeaderModel
+    assert metadata.response_model is ResponseModel
+
+
+def test_get_validation_metadata_returns_none_for_non_decorated_function() -> None:
+    def plain_handler(req: HttpRequest) -> dict[str, bool]:
+        return {"ok": True}
+
+    assert get_validation_metadata(plain_handler) is None
+
+
+def test_validation_metadata_is_frozen() -> None:
+    @validate_http(body=BodyModel)
+    def handler(req: HttpRequest, body: BodyModel) -> dict[str, bool]:
+        return {"ok": True}
+
+    metadata = get_validation_metadata(handler)
+    assert metadata is not None
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(metadata, "body", QueryModel)


### PR DESCRIPTION
## Summary
- add immutable `ValidationMetadata` typing updates and attach `_af_validation_metadata` on the decorator-created wrapper in `validate_http`
- add `tests/test_validation_metadata.py` to verify discoverability on decorated handlers, `None` for plain functions, and dataclass immutability
- keep public API compatibility for `ValidationMetadata` and `get_validation_metadata` exports used by OpenAPI bridge integration

## Validation
- `make test`
- `make lint`
- `make typecheck`

Closes #143