### PR TITLE
refactor: rename metadata attr to _azure_functions_metadata

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,16 +7,14 @@ from azure_functions_validation import (
     ErrorFormatter,
     ResponseValidationError,
     SerializationError,
-    ValidationMetadata,
-    get_validation_metadata,
     validate_http,
 )
 ```
 
 !!! note "Public surface"
     The package exports: `validate_http`, `ResponseValidationError`,
-    `ErrorFormatter`, `SerializationError`, `ValidationMetadata`, and
-    `get_validation_metadata`. Pipeline and adapter internals are not public contracts.
+    `ErrorFormatter`, and `SerializationError`. Pipeline and adapter internals
+    are not public contracts.
 
 ## `validate_http`
 
@@ -235,41 +233,6 @@ Common status codes:
     - path errors: `loc` starts with `"path"`
     - header errors: `loc` starts with `"headers"`
     - response errors: `loc` equals `["response"]`
-
-## `ValidationMetadata`
-
-::: azure_functions_validation.ValidationMetadata
-
-### Usage example: accessing validation metadata
-
-```python
-from azure_functions_validation import validate_http, get_validation_metadata
-from pydantic import BaseModel
-
-
-class Body(BaseModel):
-    name: str
-
-
-@validate_http(body=Body)
-def handler(req, body: Body) -> dict:
-    return {"name": body.name}
-
-
-meta = get_validation_metadata(handler)
-assert meta is not None
-assert meta.body is Body
-```
-
-## `get_validation_metadata`
-
-::: azure_functions_validation.get_validation_metadata
-
-!!! note "Return value"
-    Returns `None` if the function was not decorated with `@validate_http`.
-    This allows external tools to safely check for metadata presence without
-    catching exceptions.
-
 
 ## Internal references
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -344,21 +344,17 @@ def test_create_user_validation_error() -> None:
 
 ## External tool integration
 
-`@validate_http` attaches a `ValidationMetadata` frozen dataclass to the wrapper
-function. External packages can use `get_validation_metadata()` to discover the
-Pydantic models associated with a validated handler.
+`@validate_http` attaches metadata to the wrapper function via the ecosystem-wide
+`_azure_functions_metadata` convention attribute. External packages can discover
+Pydantic models without importing this package:
 
 ```python
-from azure_functions_validation import get_validation_metadata
-
-
-meta = get_validation_metadata(handler)
-if meta is not None:
-    print(meta.body)           # Pydantic model class or None
-    print(meta.query)          # Pydantic model class or None
-    print(meta.path)           # Pydantic model class or None
-    print(meta.headers)        # Pydantic model class or None
-    print(meta.response_model) # Pydantic model class or None
+meta = getattr(handler, "_azure_functions_metadata", None)
+if meta and "validation" in meta:
+    validation = meta["validation"]
+    print(validation["body"])           # Pydantic model class or None
+    print(validation["query"])          # Pydantic model class or None
+    print(validation["response_model"]) # Pydantic model class or None
 ```
 
 !!! tip "Bridge integration"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -100,28 +100,6 @@ Type alias for custom error formatters. Called with:
 
 Must return a dict representing the error response body (will be JSON-serialized).
 
-### Validation Metadata
-
-```python
-from azure_functions_validation import ValidationMetadata, get_validation_metadata
-
-@dataclass(frozen=True)
-class ValidationMetadata:
-    """Metadata exposed by @validate_http for external tool integration."""
-    body: Any = None
-    query: Any = None
-    path: Any = None
-    headers: Any = None
-    response_model: Any = None
-
-def get_validation_metadata(func: Any) -> ValidationMetadata | None:
-    """Return validation metadata if the function was decorated with @validate_http.
-    Returns None if the function has no validation metadata attached."""
-```
-
-External packages (e.g., `azure-functions-openapi`) use these to discover
-Pydantic models attached to validated handlers without importing decorator internals.
-
 ## Common Patterns
 
 ### Basic Request Body Validation

--- a/llms.txt
+++ b/llms.txt
@@ -23,8 +23,6 @@ response schemas. FastAPI-like developer experience without the web framework.
 - `ErrorFormatter` — Custom error formatting callback
 - `ResponseValidationError` — Error raised when response validation fails
 - `SerializationError` — Error raised when serialization fails
-- `ValidationMetadata` — Frozen dataclass exposing validation configuration for external tools
-- `get_validation_metadata(func)` — Retrieve validation metadata from a decorated handler (returns None if absent)
 
 ## Key Concepts
 

--- a/src/azure_functions_validation/__init__.py
+++ b/src/azure_functions_validation/__init__.py
@@ -1,13 +1,11 @@
 """azure-functions-validation package."""
 
-from .decorator import ValidationMetadata, get_validation_metadata, validate_http
+from .decorator import validate_http
 from .errors import ErrorFormatter, ResponseValidationError, SerializationError
 
 __all__ = [
     "__version__",
     "validate_http",
-    "ValidationMetadata",
-    "get_validation_metadata",
     "ResponseValidationError",
     "SerializationError",
     "ErrorFormatter",

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import inspect
 from typing import Any, Callable, Mapping
 
@@ -11,21 +10,6 @@ from pydantic import TypeAdapter
 from .adapter import PydanticAdapter, ValidationAdapter
 from .errors import ErrorFormatter
 from .pipeline import PipelineConfig, run_pipeline, run_pipeline_async
-
-
-@dataclass(frozen=True)
-class ValidationMetadata:
-    """Metadata exposed by @validate_http for external tool integration.
-
-    External packages (e.g., azure-functions-openapi) can use this to
-    discover Pydantic models attached to validated handlers.
-    """
-
-    body: Any | None = None
-    query: Any | None = None
-    path: Any | None = None
-    headers: Any | None = None
-    response_model: Any | None = None
 
 
 def validate_http(
@@ -91,17 +75,6 @@ def validate_http(
         )
 
         wrapper = _make_wrapper(func, config, is_async=is_async)
-        setattr(
-            wrapper,
-            "_af_validation_metadata",
-            ValidationMetadata(
-                body=body,
-                query=query,
-                path=path,
-                headers=headers,
-                response_model=response_model,
-            ),
-        )
         return wrapper
 
     return decorator
@@ -243,58 +216,18 @@ def _make_wrapper(
     wrapper.__annotations__ = {}
 
     # Expose validation metadata for external tool integration (e.g., OpenAPI bridge).
-    # Uses the toolkit-wide convention attribute so consumers never need to import
+    # Uses the ecosystem-wide convention attribute so consumers never need to import
     # this package.  The "validation" namespace is reserved for this package.
-    setattr(
-        wrapper,
-        "_azure_functions_toolkit_metadata",
-        {
-            "validation": {
-                "version": 1,
-                "body": config.body,
-                "query": config.query,
-                "path": config.path,
-                "headers": config.headers,
-                "response_model": config.response_model,
-            }
-        },
-    )
-
-    # Legacy attribute for backward compatibility with consumers that read
-    # ``_af_validation_metadata`` (azure-functions-openapi <0.17).
-    setattr(
-        wrapper,
-        "_af_validation_metadata",
-        ValidationMetadata(
-            body=config.body,
-            query=config.query,
-            path=config.path,
-            headers=config.headers,
-            response_model=config.response_model,
-        ),
-    )
+    _meta = dict(getattr(wrapper, "_azure_functions_metadata", None) or {})
+    _meta["validation"] = {
+        "version": 1,
+        "body": config.body,
+        "query": config.query,
+        "path": config.path,
+        "headers": config.headers,
+        "response_model": config.response_model,
+    }
+    setattr(wrapper, "_azure_functions_metadata", _meta)
 
     return wrapper
 
-
-def get_validation_metadata(func: Any) -> ValidationMetadata | None:
-    """Return validation metadata if the function was decorated with @validate_http.
-
-    Checks the convention-based ``_azure_functions_toolkit_metadata`` attribute
-    first and converts it to a :class:`ValidationMetadata` instance.  Falls back
-    to the legacy ``_af_validation_metadata`` attribute for backward compatibility.
-
-    Returns None if the function has no validation metadata attached.
-    """
-    toolkit_meta = getattr(func, "_azure_functions_toolkit_metadata", None)
-    if toolkit_meta is not None:
-        validation_ns = toolkit_meta.get("validation")
-        if validation_ns is not None:
-            return ValidationMetadata(
-                body=validation_ns.get("body"),
-                query=validation_ns.get("query"),
-                path=validation_ns.get("path"),
-                headers=validation_ns.get("headers"),
-                response_model=validation_ns.get("response_model"),
-            )
-    return getattr(func, "_af_validation_metadata", None)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -132,8 +132,8 @@ class TestConfigurationErrors:
                 return HttpResponse("ok")
 
 
-class TestValidationMetadata:
-    """Tests for ValidationMetadata exposure on decorated functions."""
+class TestValidationNamespace:
+    """Tests for metadata exposure on decorated functions."""
 
     def test_metadata_attached_with_body(self) -> None:
         """Decorated function exposes body model in metadata."""
@@ -142,16 +142,15 @@ class TestValidationMetadata:
         def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
             return HttpResponse("ok")
 
-        from azure_functions_validation import ValidationMetadata, get_validation_metadata
-
-        meta = get_validation_metadata(handler)
+        meta = getattr(handler, "_azure_functions_metadata", None)
         assert meta is not None
-        assert isinstance(meta, ValidationMetadata)
-        assert meta.body is UserModel
-        assert meta.query is None
-        assert meta.path is None
-        assert meta.headers is None
-        assert meta.response_model is None
+        assert "validation" in meta
+        validation = meta["validation"]
+        assert validation["body"] is UserModel
+        assert validation["query"] is None
+        assert validation["path"] is None
+        assert validation["headers"] is None
+        assert validation["response_model"] is None
 
     def test_metadata_attached_with_all_params(self) -> None:
         """Decorated function exposes all configured models."""
@@ -172,15 +171,14 @@ class TestValidationMetadata:
         ) -> HttpResponse:
             return HttpResponse("ok")
 
-        from azure_functions_validation import get_validation_metadata
-
-        meta = get_validation_metadata(handler)
+        meta = getattr(handler, "_azure_functions_metadata", None)
         assert meta is not None
-        assert meta.body is UserModel
-        assert meta.query is QueryModel
-        assert meta.path is PathModel
-        assert meta.headers is HeaderModel
-        assert meta.response_model is UserModel
+        validation = meta["validation"]
+        assert validation["body"] is UserModel
+        assert validation["query"] is QueryModel
+        assert validation["path"] is PathModel
+        assert validation["headers"] is HeaderModel
+        assert validation["response_model"] is UserModel
 
     def test_metadata_with_request_model_shorthand(self) -> None:
         """request_model shorthand maps to body in metadata."""
@@ -189,35 +187,17 @@ class TestValidationMetadata:
         def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
             return HttpResponse("ok")
 
-        from azure_functions_validation import get_validation_metadata
-
-        meta = get_validation_metadata(handler)
+        meta = getattr(handler, "_azure_functions_metadata", None)
         assert meta is not None
-        assert meta.body is UserModel
+        assert meta["validation"]["body"] is UserModel
 
     def test_metadata_none_on_undecorated_function(self) -> None:
-        """Non-decorated function returns None."""
+        """Non-decorated function has no metadata."""
 
         def handler(req: HttpRequest) -> HttpResponse:
             return HttpResponse("ok")
 
-        from azure_functions_validation import get_validation_metadata
-
-        assert get_validation_metadata(handler) is None
-
-    def test_metadata_frozen(self) -> None:
-        """ValidationMetadata is immutable."""
-
-        @validate_http(body=UserModel)
-        def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
-            return HttpResponse("ok")
-
-        from azure_functions_validation import get_validation_metadata
-
-        meta = get_validation_metadata(handler)
-        assert meta is not None
-        with pytest.raises(AttributeError):
-            setattr(meta, "body", None)
+        assert getattr(handler, "_azure_functions_metadata", None) is None
 
     def test_metadata_with_response_model_only(self) -> None:
         """Metadata correctly captures response_model without request models."""
@@ -226,12 +206,11 @@ class TestValidationMetadata:
         def handler(req: HttpRequest) -> dict[str, object]:
             return {"name": "Alice", "age": 30}
 
-        from azure_functions_validation import get_validation_metadata
-
-        meta = get_validation_metadata(handler)
+        meta = getattr(handler, "_azure_functions_metadata", None)
         assert meta is not None
-        assert meta.body is None
-        assert meta.response_model is UserModel
+        validation = meta["validation"]
+        assert validation["body"] is None
+        assert validation["response_model"] is UserModel
 
     def test_metadata_on_async_handler(self) -> None:
         """Async handlers also expose metadata."""
@@ -240,9 +219,8 @@ class TestValidationMetadata:
         async def handler(req: HttpRequest, body: UserModel) -> dict[str, object]:
             return {"name": body.name, "age": body.age}
 
-        from azure_functions_validation import get_validation_metadata
-
-        meta = get_validation_metadata(handler)
+        meta = getattr(handler, "_azure_functions_metadata", None)
         assert meta is not None
-        assert meta.body is UserModel
-        assert meta.response_model is UserModel
+        validation = meta["validation"]
+        assert validation["body"] is UserModel
+        assert validation["response_model"] is UserModel

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -11,8 +11,6 @@ import azure_functions_validation
 from azure_functions_validation import (
     ErrorFormatter,
     ResponseValidationError,
-    ValidationMetadata,
-    get_validation_metadata,
     validate_http,
 )
 
@@ -28,8 +26,6 @@ class TestAPISurface:
         assert set(azure_functions_validation.__all__) == {
             "__version__",
             "validate_http",
-            "ValidationMetadata",
-            "get_validation_metadata",
             "ResponseValidationError",
             "SerializationError",
             "ErrorFormatter",
@@ -40,12 +36,6 @@ class TestAPISurface:
 
     def test_validate_http_is_callable(self) -> None:
         assert callable(validate_http)
-
-    def test_validation_metadata_exported(self) -> None:
-        assert ValidationMetadata is not None
-
-    def test_get_validation_metadata_is_callable(self) -> None:
-        assert callable(get_validation_metadata)
 
     def test_response_validation_error_is_exception(self) -> None:
         assert issubclass(ResponseValidationError, Exception)

--- a/tests/test_toolkit_metadata.py
+++ b/tests/test_toolkit_metadata.py
@@ -1,4 +1,4 @@
-"""Tests for the _azure_functions_toolkit_metadata convention.
+"""Tests for the _azure_functions_metadata convention.
 
 Mirrors test_toolkit_metadata.py in sibling packages (db, logging, langgraph)
 to ensure consistent convention compliance across the ecosystem.
@@ -12,13 +12,13 @@ from unittest.mock import Mock
 from azure.functions import HttpRequest
 from pydantic import BaseModel
 
-from azure_functions_validation import ValidationMetadata, get_validation_metadata, validate_http
+from azure_functions_validation import validate_http
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-_TOOLKIT_META_ATTR = "_azure_functions_toolkit_metadata"
+_TOOLKIT_META_ATTR = "_azure_functions_metadata"
 
 
 class UserModel(BaseModel):
@@ -47,7 +47,7 @@ def _make_request(body: bytes = b'{"name": "Alice", "age": 30}') -> Mock:
 
 
 class TestToolkitMetadataConvention:
-    """Verify _azure_functions_toolkit_metadata convention compliance."""
+    """Verify _azure_functions_metadata convention compliance."""
 
     def test_metadata_attribute_exists_on_decorated_function(self) -> None:
         @validate_http(body=UserModel)
@@ -102,21 +102,20 @@ class TestToolkitMetadataConvention:
         assert payload["headers"] is None
         assert payload["response_model"] is UserModel
 
-    def test_get_validation_metadata_returns_dataclass(self) -> None:
+    def test_merge_preserves_existing_metadata(self) -> None:
+        """Validation decorator must merge, not overwrite existing metadata."""
+
         @validate_http(body=UserModel)
         def handler(req: HttpRequest, body: UserModel) -> dict[str, object]:
             return {"ok": True}
 
-        result = get_validation_metadata(handler)
-        assert result is not None
-        assert isinstance(result, ValidationMetadata)
-        assert result.body is UserModel
+        meta = getattr(handler, _TOOLKIT_META_ATTR)
+        meta["other_package"] = {"version": 1, "data": "test"}
+        setattr(handler, "_azure_functions_metadata", meta)
 
-    def test_get_validation_metadata_returns_none_for_plain_function(self) -> None:
-        def handler(req: HttpRequest) -> dict[str, object]:
-            return {"ok": True}
-
-        assert get_validation_metadata(handler) is None
+        current = getattr(handler, _TOOLKIT_META_ATTR)
+        assert "validation" in current
+        assert "other_package" in current
 
     def test_namespace_preservation_with_foreign_metadata(self) -> None:
         """Other namespaces set before decoration must survive."""
@@ -146,9 +145,3 @@ class TestToolkitMetadataConvention:
         meta = getattr(handler, _TOOLKIT_META_ATTR)
         assert "validation" in meta
         assert meta["validation"]["body"] is UserModel
-
-    def test_get_validation_metadata_importable(self) -> None:
-        """get_validation_metadata must be importable from the package."""
-        from azure_functions_validation import get_validation_metadata as getter
-
-        assert callable(getter)

--- a/tests/test_validation_metadata.py
+++ b/tests/test_validation_metadata.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError
-
 from azure.functions import HttpRequest
 from pydantic import BaseModel
-import pytest
 
-from azure_functions_validation import get_validation_metadata, validate_http
+from azure_functions_validation import validate_http
 
 
 class BodyModel(BaseModel):
@@ -46,29 +43,19 @@ def test_metadata_discoverable_on_decorated_function() -> None:
     ) -> ResponseModel:
         return ResponseModel(ok=True)
 
-    metadata = get_validation_metadata(handler)
+    metadata = getattr(handler, "_azure_functions_metadata", None)
     assert metadata is not None
-    assert metadata.body is BodyModel
-    assert metadata.query is QueryModel
-    assert metadata.path is PathModel
-    assert metadata.headers is HeaderModel
-    assert metadata.response_model is ResponseModel
+    assert "validation" in metadata
+    validation = metadata["validation"]
+    assert validation["body"] is BodyModel
+    assert validation["query"] is QueryModel
+    assert validation["path"] is PathModel
+    assert validation["headers"] is HeaderModel
+    assert validation["response_model"] is ResponseModel
 
 
-def test_get_validation_metadata_returns_none_for_non_decorated_function() -> None:
+def test_metadata_absent_for_non_decorated_function() -> None:
     def plain_handler(req: HttpRequest) -> dict[str, bool]:
         return {"ok": True}
 
-    assert get_validation_metadata(plain_handler) is None
-
-
-def test_validation_metadata_is_frozen() -> None:
-    @validate_http(body=BodyModel)
-    def handler(req: HttpRequest, body: BodyModel) -> dict[str, bool]:
-        return {"ok": True}
-
-    metadata = get_validation_metadata(handler)
-    assert metadata is not None
-
-    with pytest.raises(FrozenInstanceError):
-        setattr(metadata, "body", QueryModel)
+    assert getattr(plain_handler, "_azure_functions_metadata", None) is None


### PR DESCRIPTION
## Summary

- Rename convention attribute from `_azure_functions_toolkit_metadata` → `_azure_functions_metadata` for third-party decorator neutrality
- Remove deprecated `ValidationMetadata` dataclass and `get_validation_metadata()` function
- Remove legacy `_af_validation_metadata` attribute writing
- Fix overwrite bug — `@validate_http` now merges into existing metadata instead of clobbering it
- Update tests, docs (`api.md`, `usage.md`), and AI context files (`llms.txt`, `llms-full.txt`)

Closes #156

Supersedes #155 (ValidationMetadata removal — now included in this broader rename)