### PR TITLE
docs: fix GitHub Pages base URL, canonical, and sitemap after repo rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://yeongseon.github.io/azure-functions-validation/
+    url: https://yeongseon.github.io/azure-functions-validation-python/
     about: Check our documentation for usage guides and examples

--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Version: 0.6.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-validation/
+- Docs: https://yeongseon.github.io/azure-functions-validation-python/
 - Repository: https://github.com/yeongseon/azure-functions-validation
 - Azure Functions programming model: v2
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - Version: 0.6.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-validation/
+- Docs: https://yeongseon.github.io/azure-functions-validation-python/
 - Repository: https://github.com/yeongseon/azure-functions-validation
 
 ## What It Does
@@ -57,10 +57,9 @@ def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserRes
 
 ## Documentation
 
-- [Getting Started](https://yeongseon.github.io/azure-functions-validation/getting-started/)
-- [API Reference](https://yeongseon.github.io/azure-functions-validation/api/)
-- [Error Handling](https://yeongseon.github.io/azure-functions-validation/error-handling/)
-- [Deployment Guide](https://yeongseon.github.io/azure-functions-validation/deployment/)
+- [Getting Started](https://yeongseon.github.io/azure-functions-validation-python/getting-started/)
+- [API Reference](https://yeongseon.github.io/azure-functions-validation-python/api/)
+- [Deployment Guide](https://yeongseon.github.io/azure-functions-validation-python/deployment/)
 
 ## Ecosystem
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Azure Functions Validation
 site_description: Validation and serialization for Python-based Azure Functions
 site_author: Yeongseon Choe
-site_url: https://yeongseon.github.io/azure-functions-validation/
+site_url: https://yeongseon.github.io/azure-functions-validation-python/
 repo_url: https://github.com/yeongseon/azure-functions-validation
 edit_uri: edit/main/docs/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://yeongseon.github.io/azure-functions-validation/"
-Documentation = "https://yeongseon.github.io/azure-functions-validation/"
+Homepage = "https://yeongseon.github.io/azure-functions-validation-python/"
+Documentation = "https://yeongseon.github.io/azure-functions-validation-python/"
 Repository = "https://github.com/yeongseon/azure-functions-validation"
 Issues = "https://github.com/yeongseon/azure-functions-validation/issues"
 


### PR DESCRIPTION
Closes #167

## Summary

- Live docs are served at `https://yeongseon.github.io/azure-functions-validation-python/`; the legacy `/azure-functions-validation/` path now returns **404**.
- `mkdocs.yml` `site_url` still pointed at the dead path, so the published site was emitting a wrong `<link rel="canonical">` and an incorrect `sitemap.xml` — actively misleading crawlers and link previews.
- Standardize every docs URL reference on the live `-python` path: MkDocs metadata, `pyproject.toml` project URLs, all README docs badges (incl. translations), `.github/ISSUE_TEMPLATE/config.yml`, and `llms*.txt`.
- Drop the `llms.txt` link to a non-existent `error-handling/` docs page (caught while sweeping links).

## No functional code changes

Source tree under `src/` is not touched. This is metadata + docs only.

## Out of scope (handled in follow-up PRs)

- Stale `github.com/yeongseon/azure-functions-validation` repo-slug references in badges, clone URLs, and deep links → #171 (closes #168)
- Naming explanation note in README/FAQ → #172 (closes #169)

## Pre-merge verification

```
$ grep -rn "yeongseon\.github\.io/azure-functions-validation/" \
    --include="*.md" --include="*.yml" --include="*.yaml" \
    --include="*.toml" --include="*.txt"
(no matches)
```

Acceptance criteria checked here:

- [x] `mkdocs.yml` `site_url` is `https://yeongseon.github.io/azure-functions-validation-python/`
- [x] `pyproject.toml` `Homepage` and `Documentation` use the live docs URL
- [x] README, translated READMEs, and `llms*.txt` docs links use the `-python` docs URL

## Post-merge verification

This requires the `docs.yml` workflow to redeploy GitHub Pages. After merge:

1. Wait for `docs.yml` to complete on `main`.
2. Open the docs homepage and inspect the rendered HTML:
   ```
   curl -s https://yeongseon.github.io/azure-functions-validation-python/ \
     | grep -oE '<link rel="canonical"[^>]*>'
   ```
   Expect: `href="https://yeongseon.github.io/azure-functions-validation-python/"`.
3. Spot-check `sitemap.xml`:
   ```
   curl -s https://yeongseon.github.io/azure-functions-validation-python/sitemap.xml \
     | grep -oE '<loc>[^<]*</loc>' | head
   ```
   Expect every `<loc>` under `.../azure-functions-validation-python/...`.

- [ ] After deploy, homepage `<link rel="canonical">` and `sitemap.xml` use `.../azure-functions-validation-python/...`

## Notes

- Old indexed URLs may linger because GitHub Pages does not auto-redirect between project paths. That's acceptable; we want canonicals and the sitemap to be correct going forward.
- PyPI-rendered project URLs will refresh on the next release.