### PR TITLE
chore: replace stale repo-slug links and broken badge references

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   stale-issues:
     runs-on: ubuntu-latest
-    if: github.repository == 'yeongseon/azure-functions-validation'
+    if: github.repository == 'yeongseon/azure-functions-validation-python'
 
     steps:
       - name: "Stale issues and PRs"
@@ -32,7 +32,7 @@ jobs:
 
   stale-branches:
     runs-on: ubuntu-latest
-    if: github.repository == 'yeongseon/azure-functions-validation'
+    if: github.repository == 'yeongseon/azure-functions-validation-python'
 
     steps:
       - name: "Checkout code"

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,10 +2,10 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-validation.svg)](https://pypi.org/project/azure-functions-validation/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-validation/)
-[![CI](https://github.com/yeongseon/azure-functions-validation/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-validation/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/release.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation)
+[![CI](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/publish-pypi.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -56,8 +56,8 @@ azure-functions-validation
 ローカル開発用:
 
 ```bash
-git clone https://github.com/yeongseon/azure-functions-validation.git
-cd azure-functions-validation
+git clone https://github.com/yeongseon/azure-functions-validation-python.git
+cd azure-functions-validation-python
 pip install -e .[dev]
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,10 +2,10 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-validation.svg)](https://pypi.org/project/azure-functions-validation/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-validation/)
-[![CI](https://github.com/yeongseon/azure-functions-validation/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-validation/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/release.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation)
+[![CI](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/publish-pypi.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -56,8 +56,8 @@ azure-functions-validation
 로컬 개발용:
 
 ```bash
-git clone https://github.com/yeongseon/azure-functions-validation.git
-cd azure-functions-validation
+git clone https://github.com/yeongseon/azure-functions-validation-python.git
+cd azure-functions-validation-python
 pip install -e .[dev]
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-validation.svg)](https://pypi.org/project/azure-functions-validation/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-validation/)
-[![CI](https://github.com/yeongseon/azure-functions-validation/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-validation/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/publish-pypi.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation)
+[![CI](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/publish-pypi.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -207,8 +207,8 @@ azure-functions-validation
 For local development:
 
 ```bash
-git clone https://github.com/yeongseon/azure-functions-validation.git
-cd azure-functions-validation
+git clone https://github.com/yeongseon/azure-functions-validation-python.git
+cd azure-functions-validation-python
 pip install -e .[dev]
 ```
 
@@ -347,8 +347,8 @@ When integrating with LLM-powered coding assistants, provide these files for con
 - **`llms-full.txt`** — Expanded reference with full signatures and patterns
 
 Reference the files at repository root:
-- https://github.com/yeongseon/azure-functions-validation/blob/main/llms.txt
-- https://github.com/yeongseon/azure-functions-validation/blob/main/llms-full.txt
+- https://github.com/yeongseon/azure-functions-validation-python/blob/main/llms.txt
+- https://github.com/yeongseon/azure-functions-validation-python/blob/main/llms-full.txt
 
 ## Disclaimer
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,10 +2,10 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-validation.svg)](https://pypi.org/project/azure-functions-validation/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-validation/)
-[![CI](https://github.com/yeongseon/azure-functions-validation/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-validation/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/release.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation)
+[![CI](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/publish-pypi.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -56,8 +56,8 @@ azure-functions-validation
 本地开发：
 
 ```bash
-git clone https://github.com/yeongseon/azure-functions-validation.git
-cd azure-functions-validation
+git clone https://github.com/yeongseon/azure-functions-validation-python.git
+cd azure-functions-validation-python
 pip install -e .[dev]
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ responsibly and avoid public disclosure until a fix is available.
 
 ### Preferred: GitHub Security Advisory
 
-1. Go to the [Security Advisories page](https://github.com/yeongseon/azure-functions-validation/security/advisories/new)
+1. Go to the [Security Advisories page](https://github.com/yeongseon/azure-functions-validation-python/security/advisories/new)
 2. Click "Report a vulnerability"
 3. Submit the details in the private advisory
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,8 +9,8 @@ To begin contributing, follow these steps to set up your local development envir
 1. Fork the repository on GitHub.
 2. Clone your fork locally:
    ```bash
-   git clone https://github.com/your-username/azure-functions-validation.git
-   cd azure-functions-validation
+   git clone https://github.com/your-username/azure-functions-validation-python.git
+   cd azure-functions-validation-python
    ```
 3. Set up the development environment using Hatch:
    ```bash
@@ -120,4 +120,4 @@ The `CHANGELOG.md` is updated automatically via `git-cliff` during the release p
 
 ## Code of Conduct
 
-All contributors are expected to adhere to our [Code of Conduct](https://github.com/yeongseon/azure-functions-validation/blob/main/CODE_OF_CONDUCT.md). We strive to maintain a respectful and inclusive environment for everyone.
+All contributors are expected to adhere to our [Code of Conduct](https://github.com/yeongseon/azure-functions-validation-python/blob/main/CODE_OF_CONDUCT.md). We strive to maintain a respectful and inclusive environment for everyone.

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,8 +45,8 @@ azure-functions-validation/
 
 1. **Clone the repository**:
     ```bash
-    git clone https://github.com/yeongseon/azure-functions-validation.git
-    cd azure-functions-validation
+    git clone https://github.com/yeongseon/azure-functions-validation-python.git
+    cd azure-functions-validation-python
     ```
 
 2. **Create environment and install dependencies**:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,8 +63,8 @@ Check that your active environment is the same one used by your Function App.
 ## Local Development
 
 ```bash
-git clone https://github.com/yeongseon/azure-functions-validation.git
-cd azure-functions-validation
+git clone https://github.com/yeongseon/azure-functions-validation-python.git
+cd azure-functions-validation-python
 make install
 ```
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -115,7 +115,7 @@ pip install --index-url https://test.pypi.org/simple/ azure-functions-validation
 
 ## Related
 
-- [CHANGELOG.md](https://github.com/yeongseon/azure-functions-validation/blob/main/CHANGELOG.md)
+- [CHANGELOG.md](https://github.com/yeongseon/azure-functions-validation-python/blob/main/CHANGELOG.md)
 - [Development Guide](development.md)
 - [Contributing](contributing.md)
 - [PyPI Publishing with Hatch](https://hatch.pypa.io/latest/publishing/)

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,7 +10,7 @@ If you discover a security vulnerability in this project, please report it priva
 
 The most secure way to report a vulnerability is through a GitHub Security Advisory. This allows for private collaboration between the reporter and maintainers.
 
-1. Navigate to the [Security Advisories page](https://github.com/yeongseon/azure-functions-validation/security/advisories/new).
+1. Navigate to the [Security Advisories page](https://github.com/yeongseon/azure-functions-validation-python/security/advisories/new).
 2. Click "Report a vulnerability" or "New advisory".
 3. Provide the details of the issue in the private advisory form.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-validation-python/
-- Repository: https://github.com/yeongseon/azure-functions-validation
+- Repository: https://github.com/yeongseon/azure-functions-validation-python
 - Azure Functions programming model: v2
 
 ## Installation
@@ -20,7 +20,7 @@ pip install azure-functions-validation
 
 For local development:
 ```bash
-git clone https://github.com/yeongseon/azure-functions-validation.git
+git clone https://github.com/yeongseon/azure-functions-validation-python.git
 cd azure-functions-validation
 pip install -e .[dev]
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-validation-python/
-- Repository: https://github.com/yeongseon/azure-functions-validation
+- Repository: https://github.com/yeongseon/azure-functions-validation-python
 
 ## What It Does
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Azure Functions Validation
 site_description: Validation and serialization for Python-based Azure Functions
 site_author: Yeongseon Choe
 site_url: https://yeongseon.github.io/azure-functions-validation-python/
-repo_url: https://github.com/yeongseon/azure-functions-validation
+repo_url: https://github.com/yeongseon/azure-functions-validation-python
 edit_uri: edit/main/docs/
 
 theme:
@@ -71,7 +71,7 @@ plugins:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/yeongseon/azure-functions-validation
+      link: https://github.com/yeongseon/azure-functions-validation-python
   copyright: |
     © 2026 Yeongseon Choe – MIT Licensed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
 [project.urls]
 Homepage = "https://yeongseon.github.io/azure-functions-validation-python/"
 Documentation = "https://yeongseon.github.io/azure-functions-validation-python/"
-Repository = "https://github.com/yeongseon/azure-functions-validation"
-Issues = "https://github.com/yeongseon/azure-functions-validation/issues"
+Repository = "https://github.com/yeongseon/azure-functions-validation-python"
+Issues = "https://github.com/yeongseon/azure-functions-validation-python/issues"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Closes #168

## Summary

The repo was renamed `azure-functions-validation` → `azure-functions-validation-python`. GitHub silently redirects plain repo URLs, but badges, Codecov, deep links, workflow guards, and anything that re-emits these URLs verbatim do not.

This PR sweeps every stale reference and also fixes a related bug surfaced during the sweep.

## No functional code changes

Source tree under `src/` is **not** touched. Tests are not touched. This is purely metadata, documentation, badges, and a workflow `if:` guard. Diff is mechanical text replacement (15 files, +45 / −45) and can be reviewed by reading the categories below rather than line-by-line.

## Changes

### Metadata / config
- `pyproject.toml`: `Repository`, `Issues`
- `mkdocs.yml`: `repo_url`, social link
- `.github/workflows/stale.yml`: `github.repository` guards (otherwise the workflow silently no-ops on the renamed repo)

### Badges and links
- `README.md` + `README.ko.md` + `README.ja.md` + `README.zh-CN.md`:
  - CI / Release / Security / codecov badge URLs
  - `llms.txt` / `llms-full.txt` blob links
- **Bug fix:** translated READMEs' Release badge pointed at `release.yml`, a workflow that does not exist. Repointed at `publish-pypi.yml` to match `README.md`.

### Documentation deep links
- `SECURITY.md`, `docs/security.md`: security-advisory deep link
- `docs/development.md`, `docs/installation.md`, `docs/release_process.md`, `docs/contributing.md`: clone URLs, `CHANGELOG.md` and `CODE_OF_CONDUCT.md` deep links

### Clone instructions
- All `git clone .../azure-functions-validation.git` → `...-python.git`
- All `cd azure-functions-validation` → `cd azure-functions-validation-python` (otherwise the next step in the instructions silently fails)

### llms files
- `llms.txt`, `llms-full.txt`: `Repository` field and clone URL

## Out of scope (handled in other PRs)

- Broken docs base URL / canonical / sitemap → #170 (closes #167)
- Naming explanation note → #172 (closes #169)

## Acceptance criteria (#168)

- [x] No active docs/metadata file contains `github.com/yeongseon/azure-functions-validation` without the `-python` suffix
- [x] `pyproject.toml` `Repository` / `Issues` use `azure-functions-validation-python`
- [x] `mkdocs.yml` `repo_url` and the GitHub social link use the new slug
- [x] All README badges (incl. translations) point at the current repo and **real** workflow files
- [x] Codecov badge/links use the current repo slug
- [x] `git clone` examples use the new repo URL and matching `cd azure-functions-validation-python`
- [x] Deep links in docs (`security/advisories/new`, `blob/main/CODE_OF_CONDUCT.md`, `CHANGELOG.md`, `llms*.txt`) use the new slug
- [x] (already handled in #170) `llms.txt` no longer links to non-existent `error-handling/` page

## Verification

```
$ grep -rn "yeongseon/azure-functions-validation[^-a-zA-Z0-9_]" \
    --include="*.md" --include="*.yml" --include="*.yaml" \
    --include="*.toml" --include="*.txt"
(no matches)

$ grep -rn "workflows/release\.yml" --include="*.md"
(no matches)

$ grep -rn "cd azure-functions-validation\$" --include="*.md"
(no matches)
```

## Notes

- PyPI's rendered project URLs and README will refresh on the next release; nothing to do here.
- This PR and #170 touch overlapping files but disjoint lines, so no merge-order conflict regardless of which lands first.