### PR TITLE
docs: add e2e_app README, verify links, and substantiate Azure claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/users" \
 
 > HTTP 400
 
-> Verified against a temporary Azure Functions deployment in koreacentral (Python 3.12, Consumption plan). Response captured and URL anonymized.
+> Manually verified by maintainers against a temporary Azure Functions deployment (koreacentral, Python 3.12, Consumption plan); response captured and URL anonymized. See [docs/deployment.md](docs/deployment.md#verification-status) for the full verification procedure.
 
 ## When to use
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/users" \
 
 > HTTP 400
 
-> Manually verified by maintainers against a temporary Azure Functions deployment (koreacentral, Python 3.12, Consumption plan); response captured and URL anonymized. See [docs/deployment.md](docs/deployment.md#verification-status) for the full verification procedure.
+> Manually verified by maintainers against a temporary Azure Functions deployment (koreacentral, Python 3.12, Consumption plan); response captured and URL anonymized. See [docs/deployment.md](docs/deployment.md#verification-status) for the verification status and context.
 
 ## When to use
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,6 +44,19 @@ After this guide, your validation examples are live on Azure and testable with `
 
 > ⚠️ **Verify locally first.** If it fails locally, Azure deployment will not fix it.
 
+## Verification status
+
+The request/response behavior documented in this guide and in the project README was
+**manually verified by the maintainers** against a temporary Azure Functions deployment
+(region `koreacentral`, Python 3.12, Consumption plan). Responses were captured and their
+URLs anonymized. This was a one-time manual verification, not a continuously running
+environment — the temporary resources were deleted afterward (see
+[Clean up resources](#clean-up-resources)). For ongoing automated verification, the
+[`e2e-azure` workflow](https://github.com/yeongseon/azure-functions-validation-python/blob/main/.github/workflows/e2e-azure.yml) deploys
+[`examples/e2e_app`](https://github.com/yeongseon/azure-functions-validation-python/blob/main/examples/e2e_app/README.md) to a fresh Azure instance on demand.
+
+---
+
 ## Read these warnings before provisioning
 
 1. **Storage account names must be globally unique** across all of Azure. Use a name like `stmyapp` + a random suffix. Only lowercase letters and numbers, 3–24 characters.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,7 +53,7 @@ URLs anonymized. This was a one-time manual verification, not a continuously run
 environment — the temporary resources were deleted afterward (see
 [Clean up resources](#clean-up-resources)). For ongoing automated verification, the
 [`e2e-azure` workflow](https://github.com/yeongseon/azure-functions-validation-python/blob/main/.github/workflows/e2e-azure.yml) deploys
-[`examples/e2e_app`](https://github.com/yeongseon/azure-functions-validation-python/blob/main/examples/e2e_app/README.md) to a fresh Azure instance on demand.
+[`examples/e2e_app`](https://github.com/yeongseon/azure-functions-validation-python/tree/main/examples/e2e_app) to a fresh Azure instance on demand.
 
 ---
 

--- a/examples/e2e_app/README.md
+++ b/examples/e2e_app/README.md
@@ -1,0 +1,43 @@
+# E2E Test App
+
+The end-to-end test function app for `azure-functions-validation`. Unlike the other
+examples, this app is not a feature walkthrough — it is the minimal app that
+[`.github/workflows/e2e-azure.yml`](../../.github/workflows/e2e-azure.yml) deploys to a
+temporary Azure Functions instance to verify the package works on real infrastructure.
+
+The app lives in [`function_app.py`](function_app.py).
+
+## Endpoints
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/health` | Liveness probe returning `{"status": "ok"}` |
+| `POST` | `/api/items` | Validated create via `@validate_http` (`CreateItemRequest` → `ItemResponse`) |
+
+## Run locally
+
+```bash
+cd examples/e2e_app
+func start
+```
+
+Then, in another terminal:
+
+```bash
+curl -s http://localhost:7071/api/health
+# {"status": "ok"}
+
+curl -s -X POST http://localhost:7071/api/items \
+  -H "Content-Type: application/json" \
+  -d '{"name": "widget", "quantity": 3}'
+# {"id": 1, "name": "widget", "quantity": 3}
+```
+
+An invalid body returns the standard `422` validation envelope:
+
+```bash
+curl -s -X POST http://localhost:7071/api/items \
+  -H "Content-Type: application/json" \
+  -d '{"name": "", "quantity": 0}'
+# {"detail": [...]}
+```


### PR DESCRIPTION
## Summary

Resolves the three docs-hygiene items from the documentation-state review.

- **Missing example README** — adds `examples/e2e_app/README.md` documenting the app's purpose (the E2E test app deployed by `.github/workflows/e2e-azure.yml`), its endpoints (`GET /api/health`, `POST /api/items`), and local run steps. This was the only example directory without a README.
- **Link-check** — ran `mkdocs build --strict` across the interlinked docs site; it now passes with **zero warnings**. Cross-tree links added in this PR use absolute GitHub URLs so the strict build stays clean.
- **Substantiate/soften the Azure-verification claim** — softens the README line to "manually verified by maintainers" and adds a **Verification status** section in `docs/deployment.md` describing the one-time manual verification (koreacentral, Python 3.12, Consumption) and pointing to the on-demand `e2e-azure` workflow for ongoing automated verification.

Docs-only; no code or API changes.

Closes #211