### PR TITLE
test: unskip error-location test and add shared conftest fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+"""Shared pytest fixtures for the azure-functions-validation test suite.
+
+Fixtures declared here are auto-discovered by pytest and available to every
+test module without re-declaration, matching the convention used by sibling
+DX Toolkit repositories (langgraph, durable-graph, db).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+from unittest.mock import Mock
+
+from azure.functions import HttpRequest
+import pytest
+
+
+@pytest.fixture
+def mock_request_factory() -> Callable[..., HttpRequest]:
+    """Return a factory that builds mock ``HttpRequest`` objects.
+
+    The factory accepts the request attributes exercised by the pipeline
+    (method, url, body, params, route_params, headers) and returns a
+    ``Mock`` spec'd against ``HttpRequest`` so attribute access is validated.
+    """
+
+    def _create_request(
+        method: str = "GET",
+        url: str = "http://example.com",
+        body: bytes = b"",
+        params: Optional[Dict[str, str]] = None,
+        route_params: Optional[Dict[str, str]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> HttpRequest:
+        mock_req = Mock(spec=HttpRequest)
+        mock_req.method = method
+        mock_req.url = url
+        mock_req.get_body.return_value = body
+        mock_req.params = params or {}
+        mock_req.route_params = route_params or {}
+        mock_req.headers = headers or {}
+
+        return mock_req
+
+    return _create_request

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,7 +9,7 @@ async handlers, and response model validation — all of which now live in
 
 import asyncio
 import json
-from typing import Callable, Dict, Optional, TypeAlias
+from typing import Callable, TypeAlias
 from unittest.mock import Mock
 
 from azure.functions import HttpRequest
@@ -72,31 +72,7 @@ class HeaderModel(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def mock_request_factory() -> Callable[..., HttpRequest]:
-    """Create a mock HttpRequest factory."""
-
-    def _create_request(
-        method: str = "GET",
-        url: str = "http://example.com",
-        body: bytes = b"",
-        params: Optional[Dict[str, str]] = None,
-        route_params: Optional[Dict[str, str]] = None,
-        headers: Optional[Dict[str, str]] = None,
-    ) -> HttpRequest:
-        """Create mock HttpRequest."""
-        mock_req = Mock(spec=HttpRequest)
-        mock_req.method = method
-        mock_req.url = url
-        mock_req.get_body.return_value = body
-        mock_req.params = params or {}
-        mock_req.route_params = route_params or {}
-        mock_req.headers = headers or {}
-
-        return mock_req
-
-    return _create_request
-
+# ``mock_request_factory`` is provided by ``tests/conftest.py``.
 
 # ---------------------------------------------------------------------------
 # Successful validation
@@ -483,9 +459,8 @@ class TestValidationErrors:
 
         assert response.status_code == 200
 
-    @pytest.mark.skip("Error location format varies by Pydantic version")
     def test_validation_error_location(self, mock_request_factory: RequestFactory) -> None:
-        """Test that error location is correctly reported."""
+        """Error location is reported in the ``loc`` field (format-tolerant across Pydantic v2)."""
 
         @validate_http(body=UserModel)
         def handler(req: HttpRequest, body: UserModel) -> ResponseModel:


### PR DESCRIPTION
## Summary

Resolves the two test-suite quality items.

- **Unskip `test_validation_error_location`** — the test carried an unconditional `@pytest.mark.skip("Error location format varies by Pydantic version")`, so the error-location assertion was never exercised on any version. The assertion only checks that `"name"` appears in the reported `loc`, which is already tolerant of Pydantic v2 error-format differences. Removing the skip exercises the path on all supported versions (the package pins `pydantic>=2.0,<3.0`).
- **Add shared `tests/conftest.py`** — moves the broadly useful `mock_request_factory` fixture out of `test_pipeline.py` into a shared `conftest.py` so it is auto-discovered by every test module, matching the sibling toolkit repos (langgraph, durable-graph, db).

No production code changes. Locally: `ruff` clean, `mypy` clean, full suite passes with coverage **96%** (the unrelated `test_version_matches_distribution_metadata` failure only reproduces against a stale local editable install and passes in CI's fresh install).

Closes #219