### PR TITLE
refactor(pipeline): decouple adapter contract and harden worker-compat (#210)

### DIFF
--- a/src/azure_functions_validation/adapter.py
+++ b/src/azure_functions_validation/adapter.py
@@ -8,6 +8,8 @@ from azure.functions import HttpRequest
 from pydantic import BaseModel, TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
 
+from .errors import AdapterValidationError
+
 
 class ValidationAdapter(Protocol):
     """Protocol defining the interface for validation adapters."""
@@ -122,14 +124,32 @@ class PydanticAdapter:
     """Concrete validation adapter implementation using Pydantic v2."""
 
     @staticmethod
-    def _missing_body_validation_error() -> PydanticValidationError:
+    def _to_adapter_error(exc: PydanticValidationError) -> AdapterValidationError:
+        """Convert a Pydantic ``ValidationError`` into an ``AdapterValidationError``.
+
+        The library-specific exception is preserved as ``__cause__`` while the
+        normalized ``errors`` list keeps the pipeline and downstream callers
+        decoupled from Pydantic.
+        """
+        detail = [
+            {
+                "loc": list(error["loc"]),
+                "msg": error["msg"],
+                "type": error["type"],
+            }
+            for error in exc.errors()
+        ]
+        return AdapterValidationError(str(exc), detail)
+
+    @staticmethod
+    def _missing_body_validation_error() -> AdapterValidationError:
         class _MissingBodyPayload(BaseModel):
             body: Any
 
         try:
             _MissingBodyPayload.model_validate({})
         except PydanticValidationError as exc:
-            return exc
+            return PydanticAdapter._to_adapter_error(exc)
 
         raise RuntimeError("Unreachable: expected missing body validation error")
 
@@ -169,7 +189,10 @@ class PydanticAdapter:
             raise ValueError("Invalid JSON") from e
 
         # Validate with Pydantic
-        return model.model_validate(data)
+        try:
+            return model.model_validate(data)
+        except PydanticValidationError as exc:
+            raise self._to_adapter_error(exc) from exc
 
     def parse_query(self, req: HttpRequest, model: type[BaseModel]) -> Any:
         """Parse and validate query parameters.
@@ -182,7 +205,7 @@ class PydanticAdapter:
             Validated model instance
 
         Raises:
-            PydanticValidationError: If validation fails
+            AdapterValidationError: If validation fails
         """
         # Parse query parameters
         query_params = req.params or {}
@@ -193,7 +216,10 @@ class PydanticAdapter:
             query_data[key] = value
 
         # Validate with Pydantic
-        return model.model_validate(query_data)
+        try:
+            return model.model_validate(query_data)
+        except PydanticValidationError as exc:
+            raise self._to_adapter_error(exc) from exc
 
     def parse_path(self, req: HttpRequest, model: type[BaseModel]) -> Any:
         """Parse and validate path parameters.
@@ -206,13 +232,16 @@ class PydanticAdapter:
             Validated model instance
 
         Raises:
-            PydanticValidationError: If validation fails
+            AdapterValidationError: If validation fails
         """
         # Parse route parameters
         route_params = req.route_params or {}
 
         # Validate with Pydantic
-        return model.model_validate(route_params)
+        try:
+            return model.model_validate(route_params)
+        except PydanticValidationError as exc:
+            raise self._to_adapter_error(exc) from exc
 
     def parse_headers(self, req: HttpRequest, model: type[BaseModel]) -> Any:
         """Parse and validate headers.
@@ -225,7 +254,7 @@ class PydanticAdapter:
             Validated model instance
 
         Raises:
-            PydanticValidationError: If validation fails
+            AdapterValidationError: If validation fails
         """
         # Parse headers
         headers = req.headers or {}
@@ -236,7 +265,10 @@ class PydanticAdapter:
             header_data[key] = value
 
         # Validate with Pydantic
-        return model.model_validate(header_data)
+        try:
+            return model.model_validate(header_data)
+        except PydanticValidationError as exc:
+            raise self._to_adapter_error(exc) from exc
 
     def validate_response(
         self, obj: Any, model: Any,
@@ -259,10 +291,13 @@ class PydanticAdapter:
             Validated model instance
 
         Raises:
-            PydanticValidationError: If validation fails
+            AdapterValidationError: If validation fails
         """
         ta = type_adapter if type_adapter is not None else TypeAdapter(model)
-        return ta.validate_python(obj)
+        try:
+            return ta.validate_python(obj)
+        except PydanticValidationError as exc:
+            raise self._to_adapter_error(exc) from exc
 
     def serialize(self, obj: Any) -> tuple[str | bytes, str]:
         """Serialize response object to content and content-type.
@@ -323,11 +358,13 @@ class PydanticAdapter:
         """Format exception into standardized error response.
 
         Args:
-            exc: Exception to format (typically PydanticValidationError)
+            exc: Exception to format (typically AdapterValidationError)
 
         Returns:
             Error response dict with 'detail' key containing list of errors
         """
+        if isinstance(exc, AdapterValidationError):
+            return {"detail": exc.errors}
         if isinstance(exc, PydanticValidationError):
             detail = []
             for error in exc.errors():

--- a/src/azure_functions_validation/adapter.py
+++ b/src/azure_functions_validation/adapter.py
@@ -2,14 +2,43 @@
 
 import dataclasses
 import json
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 from azure.functions import HttpRequest
 from pydantic import BaseModel, TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
 
-from .errors import AdapterValidationError
+from .errors import AdapterValidationError, SerializationError
 
+
+def _json_default(value: Any) -> Any:
+    """Fallback JSON encoder for nested models/dataclasses inside dict/list."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return dataclasses.asdict(value)
+    raise SerializationError(type(value).__name__)
+
+
+def _is_dataclass_instance(obj: Any) -> bool:
+    return dataclasses.is_dataclass(obj) and not isinstance(obj, type)
+
+
+# Ordered serialization dispatch table: (type predicate, serializer).
+# The first matching predicate wins, mirroring the previous isinstance ladder.
+_SERIALIZERS: tuple[
+    tuple[Callable[[Any], bool], Callable[[Any], tuple[str | bytes, str]]], ...
+] = (
+    (lambda o: isinstance(o, BaseModel), lambda o: (o.model_dump_json(), "application/json")),
+    (
+        lambda o: isinstance(o, (dict, list)),
+        lambda o: (json.dumps(o, default=_json_default), "application/json"),
+    ),
+    (lambda o: isinstance(o, str), lambda o: (o, "text/plain; charset=utf-8")),
+    (lambda o: isinstance(o, bytes), lambda o: (o, "application/octet-stream")),
+    (lambda o: isinstance(o, (int, float, bool)), lambda o: (json.dumps(o), "application/json")),
+    (_is_dataclass_instance, lambda o: (json.dumps(dataclasses.asdict(o)), "application/json")),
+)
 
 class ValidationAdapter(Protocol):
     """Protocol defining the interface for validation adapters."""
@@ -313,46 +342,10 @@ class PydanticAdapter:
         Raises:
             SerializationError: If object type is not supported
         """
-        from .errors import SerializationError
-
-        content: str | bytes
-        content_type: str
-
-        if isinstance(obj, BaseModel):
-            # Serialize Pydantic model to JSON
-            content = obj.model_dump_json()
-            content_type = "application/json"
-        elif isinstance(obj, (dict, list)):
-            # Serialize dict/list to JSON, handling nested BaseModel instances
-            def _default_serializer(value: Any) -> Any:
-                if isinstance(value, BaseModel):
-                    return value.model_dump(mode="json")
-                if dataclasses.is_dataclass(value) and not isinstance(value, type):
-                    return dataclasses.asdict(value)
-                raise SerializationError(type(value).__name__)
-
-            content = json.dumps(obj, default=_default_serializer)
-            content_type = "application/json"
-        elif isinstance(obj, str):
-            # Plain text
-            content = obj
-            content_type = "text/plain; charset=utf-8"
-        elif isinstance(obj, bytes):
-            # Binary data
-            content = obj
-            content_type = "application/octet-stream"
-        elif isinstance(obj, (int, float, bool)):
-            # Scalar types — JSON-serialize
-            content = json.dumps(obj)
-            content_type = "application/json"
-        elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
-            # Dataclass — serialize via dataclasses.asdict
-            content = json.dumps(dataclasses.asdict(obj))
-            content_type = "application/json"
-        else:
-            raise SerializationError(type(obj).__name__)
-
-        return content, content_type
+        for predicate, serializer in _SERIALIZERS:
+            if predicate(obj):
+                return serializer(obj)
+        raise SerializationError(type(obj).__name__)
 
     def format_error(self, exc: Exception) -> dict[str, Any]:
         """Format exception into standardized error response.

--- a/src/azure_functions_validation/adapter.py
+++ b/src/azure_functions_validation/adapter.py
@@ -54,7 +54,7 @@ class ValidationAdapter(Protocol):
             Validated model instance
 
         Raises:
-            ValidationError: If body is missing or validation fails
+            AdapterValidationError: If body is missing or validation fails
             ValueError: If JSON parsing fails
         """
         ...
@@ -70,7 +70,7 @@ class ValidationAdapter(Protocol):
             Validated model instance
 
         Raises:
-            ValidationError: If validation fails
+            AdapterValidationError: If validation fails
         """
         ...
 
@@ -85,7 +85,7 @@ class ValidationAdapter(Protocol):
             Validated model instance
 
         Raises:
-            ValidationError: If validation fails
+            AdapterValidationError: If validation fails
         """
         ...
 
@@ -100,7 +100,7 @@ class ValidationAdapter(Protocol):
             Validated model instance
 
         Raises:
-            ValidationError: If validation fails
+            AdapterValidationError: If validation fails
         """
         ...
 
@@ -119,7 +119,7 @@ class ValidationAdapter(Protocol):
             Validated model instance
 
         Raises:
-            PydanticValidationError: If validation fails
+            AdapterValidationError: If validation fails
         """
         ...
 
@@ -193,7 +193,7 @@ class PydanticAdapter:
             Validated model instance
 
         Raises:
-            PydanticValidationError: If body is missing (with type="missing")
+            AdapterValidationError: If body is missing (with type="missing")
             ValueError: If JSON is invalid (with "Invalid JSON" message)
         """
         body = req.get_body()

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -151,6 +151,71 @@ def _validate_no_conflicts(
 _MISSING: Any = object()  # sentinel for absent req argument
 
 
+class WorkerCompat:
+    """Make a validation wrapper look like the original handler to the worker.
+
+    The Azure Functions worker (``index_function_app`` / ``loader.py``) inspects
+    the registered callable to locate the HTTP trigger parameter and to build
+    its annotation map.  Our wrapper uses a ``req`` positional plus a ``**_kw``
+    catch-all, which — if exposed verbatim — makes the worker either skip the
+    handler or raise ``FunctionLoadError``.  This strategy object applies the
+    three compatibility shims that hide those internals.
+    """
+
+    # Copied without setting __wrapped__.  __dict__ is intentionally OMITTED:
+    # copying it would alias wrapper.__dict__ to func.__dict__ (same object),
+    # causing later setattr(wrapper, "_azure_functions_metadata", ...) to mutate
+    # the original function's namespace and leak metadata across decorations.
+    _COPY_ATTRS = (
+        "__name__",
+        "__qualname__",
+        "__doc__",
+        "__module__",
+    )
+
+    def apply(self, wrapper: Callable[..., Any], func: Callable[..., Any]) -> None:
+        """Apply all worker-compatibility shims to *wrapper* in place."""
+        self._copy_safe_metadata(wrapper, func)
+        self._override_signature(wrapper)
+        self._clear_annotations(wrapper)
+
+    def _copy_safe_metadata(
+        self, wrapper: Callable[..., Any], func: Callable[..., Any]
+    ) -> None:
+        """Copy safe identity attributes without setting ``__wrapped__``.
+
+        ``functools.update_wrapper`` is intentionally not used because it sets
+        ``__wrapped__ = func``; some worker builds follow it back to the
+        original function, see ``co_argcount > 1``, and fail to register.
+        """
+        for attr in self._COPY_ATTRS:
+            try:
+                object.__setattr__(wrapper, attr, getattr(func, attr))
+            except (AttributeError, TypeError):  # pragma: no cover
+                pass
+
+    def _override_signature(self, wrapper: Callable[..., Any]) -> None:
+        """Expose only the single ``req`` parameter, hiding ``**_kw``.
+
+        Prevents ``FunctionLoadError: 'the following parameters are declared in
+        Python but not in the function definition: {'_kw'}'`` at load time.
+        """
+        _req_param = inspect.Parameter("req", inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        setattr(wrapper, "__signature__", inspect.Signature([_req_param]))
+
+    def _clear_annotations(self, wrapper: Callable[..., Any]) -> None:
+        """Clear ``__annotations__`` so ``get_type_hints`` returns ``{}``.
+
+        Otherwise the worker sees ``req: typing.Any`` and raises
+        ``FunctionLoadError: binding req has invalid non-type annotation``.
+        With no annotations it falls back to HttpRequest type inference.
+        """
+        wrapper.__annotations__ = {}
+
+
+_WORKER_COMPAT = WorkerCompat()
+
+
 def _make_wrapper(
     func: Callable[..., Any],
     config: Any,
@@ -196,38 +261,7 @@ def _make_wrapper(
 
         wrapper = _sync_wrapper
 
-    # Copy safe metadata attributes without setting __wrapped__.
-    # NOTE: __dict__ is intentionally OMITTED. Copying it via getattr/setattr
-    # would alias wrapper.__dict__ to func.__dict__ (same dict object), causing
-    # subsequent setattr(wrapper, "_azure_functions_metadata", ...) to mutate
-    # the original function's namespace and leak metadata across decorations.
-    _COPY_ATTRS = (
-        "__name__",
-        "__qualname__",
-        "__doc__",
-        "__module__",
-    )
-    for attr in _COPY_ATTRS:
-        try:
-            object.__setattr__(wrapper, attr, getattr(func, attr))
-        except (AttributeError, TypeError):  # pragma: no cover
-            pass
-
-    # Override __signature__ so inspect.signature() and the Azure Functions worker
-    # see only the single ``req`` parameter — not the internal ``**_kw`` catch-all.
-    # This prevents FunctionLoadError: 'the following parameters are declared in
-    # Python but not in the function definition: {\'_kw\'}' at function load time.
-    _req_param = inspect.Parameter("req", inspect.Parameter.POSITIONAL_OR_KEYWORD)
-    setattr(wrapper, "__signature__", inspect.Signature([_req_param]))
-
-    # Clear __annotations__ so typing.get_type_hints(wrapper) returns {} instead of
-    # {'req': Any, '_kw': Any, 'return': Any}.  The Azure Functions worker calls
-    # typing.get_type_hints(func) to build its annotation map; if it sees
-    # ``req: typing.Any``, it raises:
-    #   FunctionLoadError: binding req has invalid non-type annotation typing.Any
-    # With no annotations, the worker skips annotation validation for ``req``
-    # entirely and falls back to its default HttpRequest type inference.
-    wrapper.__annotations__ = {}
+    _WORKER_COMPAT.apply(wrapper, func)
 
     # Expose validation metadata for external tool integration (e.g., OpenAPI bridge).
     # Uses the ecosystem-wide convention attribute so consumers never need to import

--- a/src/azure_functions_validation/errors.py
+++ b/src/azure_functions_validation/errors.py
@@ -64,7 +64,7 @@ class AdapterValidationError(Exception):
     ``loc`` (list), ``msg`` (str), and ``type`` (str) keys.
     """
 
-    def __init__(self, message: str, errors: list[dict[str, Any]]):
+    def __init__(self, message: str, errors: list[dict[str, Any]]) -> None:
         """Initialize AdapterValidationError.
 
         Args:
@@ -72,7 +72,7 @@ class AdapterValidationError(Exception):
             errors: Normalized list of error detail mappings.
         """
         super().__init__(message)
-        self.errors = errors
+        self.errors: list[dict[str, Any]] = errors
 
 
 def format_error_response(

--- a/src/azure_functions_validation/errors.py
+++ b/src/azure_functions_validation/errors.py
@@ -55,6 +55,26 @@ class SerializationError(TypeError):
         self.type_name = type_name
 
 
+class AdapterValidationError(Exception):
+    """Raised by validation adapters when request/response validation fails.
+
+    Decouples the pipeline and downstream callers from the underlying
+    validation library (e.g. Pydantic).  The normalized ``errors`` list mirrors
+    the public error-response ``detail`` schema: each entry is a mapping with
+    ``loc`` (list), ``msg`` (str), and ``type`` (str) keys.
+    """
+
+    def __init__(self, message: str, errors: list[dict[str, Any]]):
+        """Initialize AdapterValidationError.
+
+        Args:
+            message: Human-readable error message.
+            errors: Normalized list of error detail mappings.
+        """
+        super().__init__(message)
+        self.errors = errors
+
+
 def format_error_response(
     exception: Exception,
     status_code: int,

--- a/src/azure_functions_validation/pipeline.py
+++ b/src/azure_functions_validation/pipeline.py
@@ -12,10 +12,10 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Mapping
 
 from azure.functions import HttpResponse
-from pydantic import ValidationError as PydanticValidationError
 
 from .adapter import PydanticAdapter, ValidationAdapter
 from .errors import (
+    AdapterValidationError,
     ErrorFormatter,
     ResponseValidationError,
     SerializationError,
@@ -156,7 +156,7 @@ def _parse_inputs(
                 parsed_inputs["body"] = parsed_body
             elif "req_model" in config.func_params and config.request_model is not None:
                 parsed_inputs["req_model"] = parsed_body
-        except PydanticValidationError as e:
+        except AdapterValidationError as e:
             return format_error_response(e, 422, config.adapter, config.error_formatter)
         except ValueError as e:
             return format_error_response(e, 400, config.adapter, config.error_formatter)
@@ -170,7 +170,7 @@ def _parse_inputs(
             # If function expects query parameter, pass it
             if "query" in config.func_params:
                 parsed_inputs["query"] = parsed_query
-        except PydanticValidationError as e:
+        except AdapterValidationError as e:
             return format_error_response(e, 422, config.adapter, config.error_formatter)
         except ValueError as e:
             return format_error_response(e, 400, config.adapter, config.error_formatter)
@@ -184,7 +184,7 @@ def _parse_inputs(
             # If function expects path parameter, pass it
             if "path" in config.func_params:
                 parsed_inputs["path"] = parsed_path
-        except PydanticValidationError as e:
+        except AdapterValidationError as e:
             return format_error_response(e, 422, config.adapter, config.error_formatter)
         except ValueError as e:
             return format_error_response(e, 400, config.adapter, config.error_formatter)
@@ -198,7 +198,7 @@ def _parse_inputs(
             # If function expects headers parameter, pass it
             if "headers" in config.func_params:
                 parsed_inputs["headers"] = parsed_headers
-        except PydanticValidationError as e:
+        except AdapterValidationError as e:
             return format_error_response(e, 422, config.adapter, config.error_formatter)
         except ValueError as e:
             return format_error_response(e, 400, config.adapter, config.error_formatter)
@@ -241,7 +241,7 @@ def _build_response(result: Any, config: PipelineConfig) -> HttpResponse:
             validated_result = config.adapter.validate_response(
                 result, config.response_model, type_adapter=config.response_type_adapter
             )
-        except PydanticValidationError:
+        except AdapterValidationError:
             response_error = ResponseValidationError("Response validation failed")
             return format_error_response(
                 response_error, 500, config.adapter, config.error_formatter,

--- a/src/azure_functions_validation/pipeline.py
+++ b/src/azure_functions_validation/pipeline.py
@@ -171,7 +171,15 @@ def _parse_inputs(
     parsed_inputs: dict[str, Any] = {}
 
     # (name, configured model, adapter parse method, injection strategy)
-    parse_specs: tuple[tuple[str, Any, Callable[..., Any], Callable[..., None]], ...] = (
+    parse_specs: tuple[
+        tuple[
+            str,
+            Any,
+            Callable[[Any, Any], Any],
+            Callable[[str, Any, PipelineConfig, dict[str, Any]], None],
+        ],
+        ...,
+    ] = (
         ("body", config.body, config.adapter.parse_body, _inject_body),
         ("query", config.query, config.adapter.parse_query, _inject_named),
         ("path", config.path, config.adapter.parse_path, _inject_named),

--- a/src/azure_functions_validation/pipeline.py
+++ b/src/azure_functions_validation/pipeline.py
@@ -49,6 +49,28 @@ class PipelineConfig:
 # ---------------------------------------------------------------------------
 
 
+def _prepare_invocation(
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    config: PipelineConfig,
+) -> tuple[HttpResponse | None, dict[str, Any]]:
+    """Resolve the request and parse inputs shared by both pipelines.
+
+    Returns a ``(early_response, merged_kwargs)`` pair.  When *early_response*
+    is not ``None`` the caller must return it immediately without invoking the
+    handler (request resolution or input validation failed).
+    """
+    try:
+        http_request = _resolve_http_request(args, kwargs, config)
+    except ValueError as e:
+        return format_error_response(e, 400, config.adapter, config.error_formatter), {}
+    parsed = _parse_inputs(http_request, config)
+    if isinstance(parsed, HttpResponse):
+        return parsed, {}
+    merged = _merge_kwargs(args, kwargs, parsed)
+    return None, merged
+
+
 def run_pipeline(
     func: Callable[..., Any],
     args: tuple[Any, ...],
@@ -56,18 +78,10 @@ def run_pipeline(
     config: PipelineConfig,
 ) -> HttpResponse:
     """Execute the sync validation pipeline."""
-    try:
-        http_request = _resolve_http_request(args, kwargs, config)
-    except ValueError as e:
-        return format_error_response(e, 400, config.adapter, config.error_formatter)
-    parsed = _parse_inputs(http_request, config)
-    if isinstance(parsed, HttpResponse):
-        return parsed
-    merged = _merge_kwargs(args, kwargs, parsed)
-    if args:
-        result = func(*args, **merged)
-    else:
-        result = func(**merged)
+    early, merged = _prepare_invocation(args, kwargs, config)
+    if early is not None:
+        return early
+    result = func(*args, **merged) if args else func(**merged)
     return _build_response(result, config)
 
 
@@ -78,18 +92,10 @@ async def run_pipeline_async(
     config: PipelineConfig,
 ) -> HttpResponse:
     """Execute the async validation pipeline."""
-    try:
-        http_request = _resolve_http_request(args, kwargs, config)
-    except ValueError as e:
-        return format_error_response(e, 400, config.adapter, config.error_formatter)
-    parsed = _parse_inputs(http_request, config)
-    if isinstance(parsed, HttpResponse):
-        return parsed
-    merged = _merge_kwargs(args, kwargs, parsed)
-    if args:
-        result = await func(*args, **merged)
-    else:
-        result = await func(**merged)
+    early, merged = _prepare_invocation(args, kwargs, config)
+    if early is not None:
+        return early
+    result = await (func(*args, **merged) if args else func(**merged))
     return _build_response(result, config)
 
 

--- a/src/azure_functions_validation/pipeline.py
+++ b/src/azure_functions_validation/pipeline.py
@@ -145,6 +145,24 @@ def _resolve_http_request(
     raise ValueError("Function must receive an HttpRequest-like object as argument")
 
 
+def _inject_named(
+    name: str, parsed: Any, config: PipelineConfig, parsed_inputs: dict[str, Any]
+) -> None:
+    """Inject a parsed value under its own name when the handler declares it."""
+    if name in config.func_params:
+        parsed_inputs[name] = parsed
+
+
+def _inject_body(
+    name: str, parsed: Any, config: PipelineConfig, parsed_inputs: dict[str, Any]
+) -> None:
+    """Inject the parsed body under ``body`` or the ``req_model`` alias."""
+    if "body" in config.func_params:
+        parsed_inputs["body"] = parsed
+    elif "req_model" in config.func_params and config.request_model is not None:
+        parsed_inputs["req_model"] = parsed
+
+
 def _parse_inputs(
     http_request: Any,
     config: PipelineConfig,
@@ -152,64 +170,28 @@ def _parse_inputs(
     """Parse and validate all configured request inputs."""
     parsed_inputs: dict[str, Any] = {}
 
-    # Parse body
-    if config.body is not None:
-        try:
-            parsed_body = config.adapter.parse_body(http_request, config.body)
+    # (name, configured model, adapter parse method, injection strategy)
+    parse_specs: tuple[tuple[str, Any, Callable[..., Any], Callable[..., None]], ...] = (
+        ("body", config.body, config.adapter.parse_body, _inject_body),
+        ("query", config.query, config.adapter.parse_query, _inject_named),
+        ("path", config.path, config.adapter.parse_path, _inject_named),
+        ("headers", config.headers, config.adapter.parse_headers, _inject_named),
+    )
 
-            # Inject body into the appropriate parameter
-            if "body" in config.func_params:
-                parsed_inputs["body"] = parsed_body
-            elif "req_model" in config.func_params and config.request_model is not None:
-                parsed_inputs["req_model"] = parsed_body
-        except AdapterValidationError as e:
-            return format_error_response(e, 422, config.adapter, config.error_formatter)
-        except ValueError as e:
-            return format_error_response(e, 400, config.adapter, config.error_formatter)
-        except Exception as e:
-            return format_error_response(e, 500, config.adapter, config.error_formatter)
-    # Parse query parameters
-    if config.query is not None:
+    for name, model, parse, inject in parse_specs:
+        if model is None:
+            continue
+        # Always validate the configured input, even if the handler ignores it.
         try:
-            # Always validate query parameters, even if function doesn't use them
-            parsed_query = config.adapter.parse_query(http_request, config.query)
-            # If function expects query parameter, pass it
-            if "query" in config.func_params:
-                parsed_inputs["query"] = parsed_query
+            parsed = parse(http_request, model)
         except AdapterValidationError as e:
             return format_error_response(e, 422, config.adapter, config.error_formatter)
         except ValueError as e:
             return format_error_response(e, 400, config.adapter, config.error_formatter)
         except Exception as e:
             return format_error_response(e, 500, config.adapter, config.error_formatter)
-    # Parse path parameters
-    if config.path is not None:
-        try:
-            # Always validate path parameters, even if function doesn't use them
-            parsed_path = config.adapter.parse_path(http_request, config.path)
-            # If function expects path parameter, pass it
-            if "path" in config.func_params:
-                parsed_inputs["path"] = parsed_path
-        except AdapterValidationError as e:
-            return format_error_response(e, 422, config.adapter, config.error_formatter)
-        except ValueError as e:
-            return format_error_response(e, 400, config.adapter, config.error_formatter)
-        except Exception as e:
-            return format_error_response(e, 500, config.adapter, config.error_formatter)
-    # Parse headers
-    if config.headers is not None:
-        try:
-            # Always validate headers, even if function doesn't use them
-            parsed_headers = config.adapter.parse_headers(http_request, config.headers)
-            # If function expects headers parameter, pass it
-            if "headers" in config.func_params:
-                parsed_inputs["headers"] = parsed_headers
-        except AdapterValidationError as e:
-            return format_error_response(e, 422, config.adapter, config.error_formatter)
-        except ValueError as e:
-            return format_error_response(e, 400, config.adapter, config.error_formatter)
-        except Exception as e:
-            return format_error_response(e, 500, config.adapter, config.error_formatter)
+        inject(name, parsed, config, parsed_inputs)
+
     # Add original HttpRequest if requested
     if "http_request" in config.func_params and config.request_param_name != "http_request":
         parsed_inputs["http_request"] = http_request

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -76,7 +76,7 @@ class TestParseBody:
         assert result.age == 30
 
     def test_empty_body(self, adapter: PydanticAdapter, mock_request: type) -> None:
-        """Test parsing empty body raises ValidationError with type='missing'."""
+        """Test parsing empty body raises AdapterValidationError with type='missing'."""
         req = mock_request(b"")
 
         with pytest.raises(AdapterValidationError) as exc_info:
@@ -172,7 +172,7 @@ class TestValidateResponse:
         assert result.age == 25
 
     def test_validate_dict_invalid(self, adapter: PydanticAdapter) -> None:
-        """Test validating invalid dict raises ValidationError."""
+        """Test validating invalid dict raises AdapterValidationError."""
         data = {"name": "Al", "age": 25}  # Name too short
 
         with pytest.raises(AdapterValidationError) as exc_info:
@@ -182,7 +182,7 @@ class TestValidateResponse:
         assert any(e["type"] == "string_too_short" for e in errors)
 
     def test_validate_invalid_type(self, adapter: PydanticAdapter) -> None:
-        """Test validating invalid response type raises PydanticValidationError."""
+        """Test validating invalid response type raises AdapterValidationError."""
         with pytest.raises(AdapterValidationError):
             adapter.validate_response("invalid", UserModel)
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Any, List, cast
 
 import azure.functions as func
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic import ValidationError as PydanticValidationError
 import pytest
 
 from azure_functions_validation.adapter import PydanticAdapter
+from azure_functions_validation.errors import AdapterValidationError
 
 if TYPE_CHECKING:
     import pytest
@@ -79,13 +79,13 @@ class TestParseBody:
         """Test parsing empty body raises ValidationError with type='missing'."""
         req = mock_request(b"")
 
-        with pytest.raises(PydanticValidationError) as exc_info:
+        with pytest.raises(AdapterValidationError) as exc_info:
             adapter.parse_body(req, UserModel)
 
-        errors = exc_info.value.errors()
+        errors = exc_info.value.errors
         assert len(errors) == 1
         assert errors[0]["type"] == "missing"
-        assert errors[0]["loc"] == ("body",)
+        assert errors[0]["loc"] == ["body"]
 
     def test_invalid_json(self, adapter: PydanticAdapter, mock_request: type) -> None:
         """Test parsing invalid JSON raises ValueError."""
@@ -102,10 +102,10 @@ class TestParseBody:
         """Test validation errors for field constraints."""
         # Name too short
         req = mock_request(b'{"name": "Al", "age": 30}')
-        with pytest.raises(PydanticValidationError) as exc_info:
+        with pytest.raises(AdapterValidationError) as exc_info:
             adapter.parse_body(req, UserModel)
 
-        errors = exc_info.value.errors()
+        errors = exc_info.value.errors
         assert any(e["type"] == "string_too_short" for e in errors)
 
     def test_validation_error_missing_field(
@@ -113,10 +113,10 @@ class TestParseBody:
     ) -> None:
         """Test validation errors for missing required field."""
         req = mock_request(b'{"name": "Alice"}')
-        with pytest.raises(PydanticValidationError) as exc_info:
+        with pytest.raises(AdapterValidationError) as exc_info:
             adapter.parse_body(req, UserModel)
 
-        errors = exc_info.value.errors()
+        errors = exc_info.value.errors
         assert any(e["type"] == "missing" for e in errors)
 
     def test_validation_error_wrong_type(
@@ -124,10 +124,10 @@ class TestParseBody:
     ) -> None:
         """Test validation errors for wrong field type."""
         req = mock_request(b'{"name": "Alice", "age": "not a number"}')
-        with pytest.raises(PydanticValidationError) as exc_info:
+        with pytest.raises(AdapterValidationError) as exc_info:
             adapter.parse_body(req, UserModel)
 
-        errors = exc_info.value.errors()
+        errors = exc_info.value.errors
         assert any("int_parsing" in e["type"] for e in errors)
 
     def test_whitespace_body_is_treated_as_missing(
@@ -135,10 +135,10 @@ class TestParseBody:
     ) -> None:
         req = mock_request(b"   ")
 
-        with pytest.raises(PydanticValidationError) as exc_info:
+        with pytest.raises(AdapterValidationError) as exc_info:
             adapter.parse_body(req, UserModel)
 
-        errors = exc_info.value.errors()
+        errors = exc_info.value.errors
         assert errors[0]["type"] == "missing"
 
     def test_invalid_utf8_body_raises_value_error(
@@ -175,15 +175,15 @@ class TestValidateResponse:
         """Test validating invalid dict raises ValidationError."""
         data = {"name": "Al", "age": 25}  # Name too short
 
-        with pytest.raises(PydanticValidationError) as exc_info:
+        with pytest.raises(AdapterValidationError) as exc_info:
             adapter.validate_response(data, UserModel)
 
-        errors = exc_info.value.errors()
+        errors = exc_info.value.errors
         assert any(e["type"] == "string_too_short" for e in errors)
 
     def test_validate_invalid_type(self, adapter: PydanticAdapter) -> None:
         """Test validating invalid response type raises PydanticValidationError."""
-        with pytest.raises(PydanticValidationError):
+        with pytest.raises(AdapterValidationError):
             adapter.validate_response("invalid", UserModel)
 
     def test_validate_list_of_dicts_against_list_type(self, adapter: PydanticAdapter) -> None:
@@ -211,7 +211,7 @@ class TestValidateResponse:
 
     def test_validate_list_type_rejects_non_list_payload(self, adapter: PydanticAdapter) -> None:
         """Test that list[UserModel] rejects a dict payload."""
-        with pytest.raises(PydanticValidationError):
+        with pytest.raises(AdapterValidationError):
             adapter.validate_response({"name": "Alice", "age": 30}, list[UserModel])
 
 
@@ -335,13 +335,30 @@ class TestFormatError:
         req = mock_request(b'{"name": "Al", "age": 30}')
         try:
             adapter.parse_body(req, UserModel)
-        except PydanticValidationError as e:
+        except AdapterValidationError as e:
             result = adapter.format_error(e)
 
             assert "detail" in result
             assert isinstance(result["detail"], list)
             assert len(result["detail"]) > 0
 
+            error = result["detail"][0]
+            assert "loc" in error
+            assert "msg" in error
+            assert "type" in error
+
+    def test_format_raw_pydantic_error_backward_compat(self, adapter: PydanticAdapter) -> None:
+        """format_error still handles a raw Pydantic ValidationError directly."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        try:
+            UserModel.model_validate({"name": "Al", "age": 30})
+        except PydanticValidationError as e:
+            result = adapter.format_error(e)
+
+            assert "detail" in result
+            assert isinstance(result["detail"], list)
+            assert len(result["detail"]) > 0
             error = result["detail"][0]
             assert "loc" in error
             assert "msg" in error


### PR DESCRIPTION
## Summary

Implements the **behavior-preserving** items from the #210 design review. All
five changes keep HTTP responses, status codes, and the public decorator API
identical — they are internal refactors that reduce coupling and duplication.

- **Decouple the pipeline from Pydantic** (#210 item 1): adapters now raise an
  adapter-owned `AdapterValidationError` (carrying a normalized `errors` list)
  instead of leaking `pydantic.ValidationError`. The pipeline and
  `format_error` handle the abstraction; the original Pydantic error is
  preserved as `__cause__`.
- **Share the sync/async pipeline core** (#210 item 3): extract
  `_prepare_invocation` so `run_pipeline` / `run_pipeline_async` no longer
  duplicate request resolution + input parsing.
- **Spec-table `_parse_inputs`** (#210 item 4): replace the 4× body/query/path/
  headers try/except blocks with a single loop over a `(name, model,
  parse_method, injection)` table.
- **Dispatch-table `serialize()`** (#210 item 6): replace the `isinstance`
  ladder with an ordered `(predicate, serializer)` registry (order preserved).
- **`WorkerCompat` strategy object** (#210 item 2, code half): isolate the
  Azure Functions worker-introspection shims (`__wrapped__` avoidance,
  `__signature__` override, `__annotations__` clearing) out of `_make_wrapper`.

## Deferred (tracked in #223)

These #210 items are intentionally **not** in this PR because they are not
behavior-preserving / are cross-repo:

- Worker-nightly CI matrix (#210 item 2, CI half)
- `request_model` deprecation warning (#210 item 5 — behavior change)
- Cross-package metadata `TypedDict` (#210 item 7 — must coordinate with
  `openapi` / `logging`)

#210 stays **open** until #223 lands its remaining items.

## Testing

- `make lint` / `make typecheck`: clean
- `make test`: 196 passed, coverage **97.5%** (≥95% floor)

## Refs

- Part of #210
- Follow-up: #223
