### PR TITLE
refactor(metadata): type the validation cross-package metadata contract

### DIFF
--- a/src/azure_functions_validation/_metadata.py
+++ b/src/azure_functions_validation/_metadata.py
@@ -1,0 +1,78 @@
+"""Typed cross-package metadata contract for the ``validation`` namespace.
+
+Toolkit convention (shared across the Azure Functions Python DX Toolkit):
+decorators attach an ``_azure_functions_metadata`` dict onto the wrapped
+handler, keyed by a package-owned *namespace* string, so sibling packages
+(e.g. ``azure-functions-openapi``) can discover metadata **without importing
+this package**.
+
+This module gives the ``"validation"`` namespace payload a checked
+``TypedDict`` shape plus a single merge helper. The contract is intentionally
+*replicated* across toolkit packages (not shared via a runtime dependency);
+keep the ``_BaseMetadata`` ``version`` field and the merge-without-clobber
+semantics identical to the sibling packages. Consumers keep their own
+read-side mirror of :class:`ValidationMetadata`.
+
+Ref: https://github.com/yeongseon/azure-functions-validation-python/issues/223
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict, cast
+
+#: Convention attribute name shared across all toolkit packages.
+METADATA_ATTR = "_azure_functions_metadata"
+
+#: Namespace owned by this package.
+NAMESPACE = "validation"
+
+#: Schema version for the ``validation`` namespace payload.
+VALIDATION_METADATA_VERSION = 1
+
+
+class _BaseMetadata(TypedDict):
+    """Fields common to every toolkit namespace payload."""
+
+    version: int
+
+
+class ValidationMetadata(_BaseMetadata):
+    """Shape of ``_azure_functions_metadata["validation"]`` (schema version 1).
+
+    The model fields hold the Pydantic model *type* (or ``None``) supplied to
+    ``@validate_http`` — deliberately typed ``Any`` because the concrete model
+    class varies per user.
+    """
+
+    body: Any
+    query: Any
+    path: Any
+    headers: Any
+    response_model: Any
+
+
+def set_validation_metadata(
+    wrapper: Any,
+    func: Any,
+    payload: ValidationMetadata,
+) -> None:
+    """Merge the ``validation`` namespace onto ``wrapper`` without clobbering others.
+
+    Seeds from any pre-existing convention attribute on ``func`` (set by other
+    decorators applied before this one), merges in ``payload`` under the
+    ``validation`` namespace, and writes the result onto ``wrapper``.
+    """
+    existing = getattr(func, METADATA_ATTR, None)
+    base: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    base[NAMESPACE] = payload
+    setattr(wrapper, METADATA_ATTR, base)
+
+
+def read_validation_metadata(func: Any) -> ValidationMetadata | None:
+    """Return the typed ``validation`` namespace payload, or ``None`` if absent."""
+    md = getattr(func, METADATA_ATTR, None)
+    if isinstance(md, dict):
+        entry = md.get(NAMESPACE)
+        if isinstance(entry, dict):
+            return cast("ValidationMetadata", entry)
+    return None

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -8,6 +8,7 @@ import warnings
 
 from pydantic import TypeAdapter
 
+from ._metadata import ValidationMetadata, set_validation_metadata
 from .adapter import PydanticAdapter, ValidationAdapter
 from .errors import ErrorFormatter
 from .pipeline import PipelineConfig, run_pipeline, run_pipeline_async
@@ -275,8 +276,7 @@ def _make_wrapper(
     # Expose validation metadata for external tool integration (e.g., OpenAPI bridge).
     # Uses the ecosystem-wide convention attribute so consumers never need to import
     # this package.  The "validation" namespace is reserved for this package.
-    _meta = dict(getattr(func, "_azure_functions_metadata", None) or {})
-    _meta["validation"] = {
+    _payload: ValidationMetadata = {
         "version": 1,
         "body": config.body,
         "query": config.query,
@@ -284,6 +284,6 @@ def _make_wrapper(
         "headers": config.headers,
         "response_model": config.response_model,
     }
-    setattr(wrapper, "_azure_functions_metadata", _meta)
+    set_validation_metadata(wrapper, func, _payload)
 
     return wrapper

--- a/tests/test_metadata_contract.py
+++ b/tests/test_metadata_contract.py
@@ -1,0 +1,111 @@
+"""Tests for the typed cross-package metadata contract (``_metadata``)."""
+
+from __future__ import annotations
+
+from azure_functions_validation._metadata import (
+    METADATA_ATTR,
+    NAMESPACE,
+    VALIDATION_METADATA_VERSION,
+    ValidationMetadata,
+    read_validation_metadata,
+    set_validation_metadata,
+)
+
+
+def _payload() -> ValidationMetadata:
+    return {
+        "version": 1,
+        "body": None,
+        "query": None,
+        "path": None,
+        "headers": None,
+        "response_model": None,
+    }
+
+
+class TestContractConstants:
+    def test_attr_name_is_toolkit_convention(self) -> None:
+        assert METADATA_ATTR == "_azure_functions_metadata"
+
+    def test_namespace_is_validation(self) -> None:
+        assert NAMESPACE == "validation"
+
+    def test_version_constant(self) -> None:
+        assert VALIDATION_METADATA_VERSION == 1
+
+
+class TestSetValidationMetadata:
+    def test_writes_payload_onto_wrapper(self) -> None:
+        def func() -> None:
+            pass
+
+        def wrapper() -> None:
+            pass
+
+        set_validation_metadata(wrapper, func, _payload())
+
+        meta = getattr(wrapper, METADATA_ATTR)
+        assert meta == {"validation": _payload()}
+
+    def test_seeds_from_existing_namespaces_on_func(self) -> None:
+        def func() -> None:
+            pass
+
+        def wrapper() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, {"db": {"version": 1, "bindings": []}})
+        set_validation_metadata(wrapper, func, _payload())
+
+        meta = getattr(wrapper, METADATA_ATTR)
+        assert meta["db"] == {"version": 1, "bindings": []}
+        assert meta["validation"] == _payload()
+
+    def test_ignores_non_dict_existing_attr(self) -> None:
+        def func() -> None:
+            pass
+
+        def wrapper() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, "not-a-dict")
+        set_validation_metadata(wrapper, func, _payload())
+
+        meta = getattr(wrapper, METADATA_ATTR)
+        assert meta == {"validation": _payload()}
+
+
+class TestReadValidationMetadata:
+    def test_returns_payload_when_present(self) -> None:
+        def func() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, {"validation": _payload()})
+        assert read_validation_metadata(func) == _payload()
+
+    def test_returns_none_when_attr_missing(self) -> None:
+        def func() -> None:
+            pass
+
+        assert read_validation_metadata(func) is None
+
+    def test_returns_none_when_attr_not_dict(self) -> None:
+        def func() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, "not-a-dict")
+        assert read_validation_metadata(func) is None
+
+    def test_returns_none_when_namespace_absent(self) -> None:
+        def func() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, {"db": {"version": 1}})
+        assert read_validation_metadata(func) is None
+
+    def test_returns_none_when_namespace_not_dict(self) -> None:
+        def func() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, {"validation": "not-a-dict"})
+        assert read_validation_metadata(func) is None


### PR DESCRIPTION
## Summary
- Add `src/azure_functions_validation/_metadata.py` giving the `_azure_functions_metadata["validation"]` payload a checked `TypedDict` shape (`ValidationMetadata`), a `_BaseMetadata` base carrying the shared `version` field, the `METADATA_ATTR` / `NAMESPACE` constants, and a `VALIDATION_METADATA_VERSION` constant.
- Provide a single `set_validation_metadata` merge-without-clobber helper plus a typed `read_validation_metadata` accessor.
- Route `@validate_http` through the typed helper. **Behavior-preserving** — the runtime dict shape is unchanged (model fields stay `Any` since the concrete Pydantic class varies per user).

## Coordination
Part of the toolkit-wide contract (logging #216, langgraph #269, db #196). The contract is replicated per repo (no cross-package runtime import); `azure-functions-openapi` reads this namespace via its own read-side mirror.

## Verification
- `make typecheck` clean (mypy, 20 files).
- Full suite green, coverage **97.69%** (≥95% gate).
- New `tests/test_metadata_contract.py` covers merge/seed/read edge cases; existing `test_toolkit_metadata.py` unchanged and passing.

Part of #223