### PR TITLE
refactor(decorator): adopt canonical copy_identity_attrs worker-compat helper (#231)

### DIFF
--- a/src/azure_functions_validation/_metadata_helpers.py
+++ b/src/azure_functions_validation/_metadata_helpers.py
@@ -1,0 +1,55 @@
+"""Canonical worker-compatibility metadata helpers.
+
+This module houses the primitive shared across the Azure Functions Python DX
+Toolkit for copying identity attributes from a user handler onto a decorator
+wrapper **without** tripping the Azure Functions worker's function-indexing
+heuristics.
+
+The primitive is intentionally kept as a small, dependency-free unit so the
+**same shape** can be mirrored verbatim across sibling packages
+(``azure-functions-logging``, ``azure-functions-validation``, ...). These
+packages are independent PyPI distributions with no shared base dependency, so
+"shared" here means a canonical, synced definition rather than a common import.
+
+Ref: https://github.com/yeongseon/azure-functions-logging/issues/216
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+# Identity attributes copied from the wrapped function onto the wrapper.
+#
+# ``functools.wraps`` / ``functools.update_wrapper`` are deliberately NOT used:
+#
+# * they set ``__wrapped__ = func`` — the Azure Functions worker may follow it
+#   during function indexing and bind the original (un-wrapped) handler instead
+#   of the wrapper, defeating the decorator;
+# * they copy ``__dict__`` — sharing the dict object aliases
+#   ``wrapper.__dict__`` with ``func.__dict__``, so later ``setattr`` calls
+#   (e.g. ``_azure_functions_metadata``) leak onto the original ``func``.
+SAFE_IDENTITY_ATTRS: tuple[str, ...] = (
+    "__name__",
+    "__qualname__",
+    "__doc__",
+    "__module__",
+)
+
+
+def copy_identity_attrs(
+    wrapper: Callable[..., Any],
+    func: Callable[..., Any],
+    attrs: tuple[str, ...] = SAFE_IDENTITY_ATTRS,
+) -> None:
+    """Copy safe identity attributes from ``func`` onto ``wrapper`` in place.
+
+    Copies only the attributes in ``attrs`` (identity metadata) and neither
+    sets ``__wrapped__`` nor copies ``__dict__``. Signature and annotation
+    handling is intentionally left to the caller because it is
+    package-specific (some packages hide parameters, others preserve them).
+    """
+    for attr in attrs:
+        try:
+            object.__setattr__(wrapper, attr, getattr(func, attr))
+        except (AttributeError, TypeError):  # pragma: no cover
+            pass

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -9,6 +9,7 @@ import warnings
 from pydantic import TypeAdapter
 
 from ._metadata import ValidationMetadata, set_validation_metadata
+from ._metadata_helpers import SAFE_IDENTITY_ATTRS, copy_identity_attrs
 from .adapter import PydanticAdapter, ValidationAdapter
 from .errors import ErrorFormatter
 from .pipeline import PipelineConfig, run_pipeline, run_pipeline_async
@@ -172,16 +173,9 @@ class WorkerCompat:
     three compatibility shims that hide those internals.
     """
 
-    # Copied without setting __wrapped__.  __dict__ is intentionally OMITTED:
-    # copying it would alias wrapper.__dict__ to func.__dict__ (same object),
-    # causing later setattr(wrapper, "_azure_functions_metadata", ...) to mutate
-    # the original function's namespace and leak metadata across decorations.
-    _COPY_ATTRS = (
-        "__name__",
-        "__qualname__",
-        "__doc__",
-        "__module__",
-    )
+    # See ._metadata_helpers.copy_identity_attrs for the rationale (no
+    # __wrapped__, no __dict__ aliasing).  The attribute set is the canonical
+    # SAFE_IDENTITY_ATTRS shared across the DX toolkit.
 
     def apply(self, wrapper: Callable[..., Any], func: Callable[..., Any]) -> None:
         """Apply all worker-compatibility shims to *wrapper* in place."""
@@ -194,15 +188,12 @@ class WorkerCompat:
     ) -> None:
         """Copy safe identity attributes without setting ``__wrapped__``.
 
+        Delegates to the canonical :func:`copy_identity_attrs` helper.
         ``functools.update_wrapper`` is intentionally not used because it sets
         ``__wrapped__ = func``; some worker builds follow it back to the
         original function, see ``co_argcount > 1``, and fail to register.
         """
-        for attr in self._COPY_ATTRS:
-            try:
-                object.__setattr__(wrapper, attr, getattr(func, attr))
-            except (AttributeError, TypeError):  # pragma: no cover
-                pass
+        copy_identity_attrs(wrapper, func, SAFE_IDENTITY_ATTRS)
 
     def _override_signature(self, wrapper: Callable[..., Any]) -> None:
         """Expose only the single ``req`` parameter, hiding ``**_kw``.

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -168,3 +168,29 @@ class TestMetadataIsolation:
 
         wrapped = validate_http(body=UserModel)(handler)
         assert not hasattr(wrapped, "__wrapped__")
+
+
+class TestCopyIdentityAttrs:
+    """The canonical ``copy_identity_attrs`` primitive must not leak state."""
+
+    def test_copies_identity_without_wrapped_or_dict_alias(self) -> None:
+        from azure_functions_validation._metadata_helpers import (
+            SAFE_IDENTITY_ATTRS,
+            copy_identity_attrs,
+        )
+
+        def func(req: object, context: object) -> None:
+            """Original docstring."""
+
+        def wrapper(*args: object, **kwargs: object) -> None:
+            pass
+
+        copy_identity_attrs(wrapper, func)
+
+        for attr in SAFE_IDENTITY_ATTRS:
+            assert getattr(wrapper, attr) == getattr(func, attr)
+        # __wrapped__ must NOT be set (defeats worker indexing otherwise).
+        assert not hasattr(wrapper, "__wrapped__")
+        # __dict__ must not be aliased: mutating wrapper must not touch func.
+        wrapper.__dict__["_marker"] = 1
+        assert "_marker" not in func.__dict__


### PR DESCRIPTION
## Context
`azure-functions-validation` carried its own copy of the worker-compat identity-copy primitive (`WorkerCompat._copy_safe_metadata` / `_COPY_ATTRS`). This adopts the canonical shape extracted in the logging package so the toolkit's worker-compat behavior stays consistent.

## Changes
- Add `_metadata_helpers.py` mirroring the logging package's `copy_identity_attrs` + `SAFE_IDENTITY_ATTRS` verbatim.
- `WorkerCompat._copy_safe_metadata` now delegates to `copy_identity_attrs`; the package-specific `_override_signature` / `_clear_annotations` shims are unchanged.
- Behavior preserved: no `__wrapped__`, no `__dict__` aliasing.
- Add a direct `TestCopyIdentityAttrs` unit test for the canonical helper.

## Verification
- ruff: clean · mypy: clean (21 files)
- Full suite passes; coverage 97.71% (≥95%).

Closes #231