### PR TITLE
docs: add blank line after JSON block in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/users" \
 ```json
 {"message": "Hello Alice", "status": "success"}
 ```
+
 Invalid requests return the same `400` error in both environments:
 
 #### Local


### PR DESCRIPTION
## Summary
- Insert a blank line after the JSON response block so the following paragraph renders as its own block.

Closes #237