### PR TITLE
docs: merge redundant Features list into What it does

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Azure Functions Python v2 handlers often drift into the same repeated problems:
 - **Automatic error responses** — invalid requests get consistent `400`/`422` JSON error bodies
 - **Response model enforcement** — mismatches raise `ResponseValidationError` (HTTP 500)
 - **Decorator-first API** — `@validate_http` wraps your handler, no boilerplate needed
+- **Custom error formatting** — per-handler error shaping via `ErrorFormatter`
 
 ## How it works
 
@@ -202,13 +203,6 @@ This package does not own:
 - API documentation and spec generation — use [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)
 - Runtime exposure or graph deployment — use [`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python)
 - Project scaffolding — use [`azure-functions-scaffold`](https://github.com/yeongseon/azure-functions-scaffold-python)
-
-## Features
-
-- Typed body, query, path, and header validation via `@validate_http`
-- Automatic 400 / 422 responses with `{"detail": [...]}` envelope
-- Response model validation — mismatches raise `ResponseValidationError` (HTTP 500)
-- Custom per-handler error formatting via `ErrorFormatter`
 
 ## Package names
 


### PR DESCRIPTION
## Summary
- Fold the unique `ErrorFormatter` bullet into `## What it does` and remove the redundant `## Features` section (no information lost).

Closes #239