### PR TITLE
docs: require translation sync in the same PR as English changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@
 - Keep documentation examples, decorator behaviour, and tests synchronized.
 - The version test in `tests/test_public_api.py` reads from `importlib.metadata` and needs no manual edits across releases.
 
+### Documentation & Translations
+- When a change touches `README.md` or any English documentation, update the translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) **in the same PR** so translations never drift from the English source.
+- This applies to any code change that alters documented behavior, CLI output, or the ecosystem/package table — not just direct edits to prose.
+- If a full translation cannot land in the same PR, add a short "translation pending" note to the affected translated file and open a tracking issue before merging.
+
 ## Issue Conventions
 
 Follow these conventions when opening issues so the backlog stays consistent with sibling DX Toolkit repositories.


### PR DESCRIPTION
## Summary
Adds a **Documentation & Translations** rule to `AGENTS.md` under `## Working Rules`: whenever a change touches `README.md` or English docs (including code changes that alter documented behavior, CLI output, or the ecosystem table), the translated READMEs (`README.ko.md` / `README.ja.md` / `README.zh-CN.md`) must be updated **in the same PR**.

Codifies the practice we just applied when syncing the Ecosystem tables.

Closes #241