### PR TITLE
fix(pipeline): log response-validation 500s with exc_info

### DIFF
--- a/src/azure_functions_validation/pipeline.py
+++ b/src/azure_functions_validation/pipeline.py
@@ -8,6 +8,9 @@ keeps ``decorator.py`` focused on configuration and wiring.
 
 from __future__ import annotations
 
+import logging
+
+
 from dataclasses import dataclass, field
 from typing import Any, Callable, Mapping
 
@@ -21,6 +24,8 @@ from .errors import (
     SerializationError,
     format_error_response,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -238,11 +243,20 @@ def _build_response(result: Any, config: PipelineConfig) -> HttpResponse:
                 result, config.response_model, type_adapter=config.response_type_adapter
             )
         except AdapterValidationError:
+            logger.error(
+                "Response validation failed for handler %r",
+                getattr(config, "request_param_name", None),
+                exc_info=True,
+            )
             response_error = ResponseValidationError("Response validation failed")
             return format_error_response(
                 response_error, 500, config.adapter, config.error_formatter,
             )
         except Exception:
+            logger.error(
+                "Unexpected error during response validation",
+                exc_info=True,
+            )
             response_error = ResponseValidationError("Response validation failed")
             return format_error_response(
                 response_error, 500, config.adapter, config.error_formatter,
@@ -251,6 +265,7 @@ def _build_response(result: Any, config: PipelineConfig) -> HttpResponse:
         try:
             content, content_type = config.adapter.serialize(validated_result)
         except (SerializationError, TypeError) as e:
+            logger.error("Failed to serialize validated response", exc_info=True)
             return format_error_response(
                 e, 500, config.adapter, config.error_formatter,
             )
@@ -263,6 +278,7 @@ def _build_response(result: Any, config: PipelineConfig) -> HttpResponse:
     try:
         content, content_type = config.adapter.serialize(result)
     except (SerializationError, TypeError) as e:
+        logger.error("Failed to serialize response", exc_info=True)
         return format_error_response(
             e, 500, config.adapter, config.error_formatter,
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,6 +9,8 @@ async handlers, and response model validation — all of which now live in
 
 import asyncio
 import json
+import logging
+import json
 from typing import Callable, TypeAlias
 from unittest.mock import Mock
 
@@ -789,6 +791,29 @@ class TestCustomErrorFormatter:
         data = json.loads(response.get_body().decode())
         assert data["error_type"] == "CONTRACT_VIOLATION"
         assert data["http_status"] == 500
+
+    def test_response_validation_failure_is_logged_with_exc_info(
+        self, mock_request_factory: RequestFactory, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A response-validation 500 must leave a log record with exception info (#250)."""
+
+        class ResponseModel(BaseModel):
+            message: str
+
+        @validate_http(body=UserModel, response_model=ResponseModel)
+        def handler(req: HttpRequest, body: UserModel) -> dict[str, object]:
+            return {"invalid": "data"}
+
+        request = mock_request_factory(body=b'{"name": "Frank", "age": 40}')
+        with caplog.at_level(logging.ERROR, logger="azure_functions_validation.pipeline"):
+            response = handler(request)
+
+        assert response.status_code == 500
+        records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert records, "expected an ERROR log record for the response-validation failure"
+        assert any(r.exc_info is not None for r in records), (
+            "expected exc_info to be attached so the cause is visible in App Insights"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Response-validation failure paths in `_build_response` caught the exception without binding or logging it; `format_error_response` sanitizes all `>=500` responses, so the real cause was silently swallowed — invisible in Application Insights.
- Add `logger.error(..., exc_info=True)` to every 500 path (response validation `AdapterValidationError` + generic, and both serialization paths).
- Client-facing sanitized body is unchanged.

## Test
- New `test_response_validation_failure_is_logged_with_exc_info` asserts an ERROR record with `exc_info` is emitted.
- Full suite green; coverage 97.5% (>=95).

Note: `tests/test_examples.py::...test_all_readme_variants_have_identical_quickstart` fails on clean `main` (pre-existing README drift) — unrelated to this PR.

Closes #250