### PR TITLE
fix(decorator): warn on wrong decorator order instead of silently disabling

### DIFF
--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -60,7 +60,15 @@ def validate_http(
         adapter = PydanticAdapter()
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        if type(func).__name__ == "FunctionBuilder":
+        if _is_function_builder(func):
+            warnings.warn(
+                "@validate_http received an Azure Functions FunctionBuilder instead of "
+                "your handler, which means it was applied ABOVE @app.route. Validation "
+                "is NOT active for this function. Place @validate_http BELOW @app.route "
+                "so it wraps the handler directly.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
             return func
 
         is_async = inspect.iscoroutinefunction(func)
@@ -97,6 +105,19 @@ def validate_http(
 # ---------------------------------------------------------------------------
 # Decorator-time helpers (configuration validation, not request processing)
 # ---------------------------------------------------------------------------
+
+def _is_function_builder(func: Any) -> bool:
+    """Return ``True`` if *func* is an Azure Functions ``FunctionBuilder``.
+
+    A ``FunctionBuilder`` reaches this decorator only when ``@validate_http`` was
+    applied *above* ``@app.route`` (wrong order), in which case the real handler
+    is never wrapped and validation is silently disabled.  We detect it via the
+    ``configure_function_builder`` method that the ``@app.route`` machinery adds
+    to the builder, falling back to a type-name match for SDK builds that lack it.
+    """
+    if hasattr(func, "configure_function_builder"):
+        return True
+    return type(func).__name__ == "FunctionBuilder"
 
 
 def _find_request_param(

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -194,3 +194,47 @@ class TestCopyIdentityAttrs:
         # __dict__ must not be aliased: mutating wrapper must not touch func.
         wrapper.__dict__["_marker"] = 1
         assert "_marker" not in func.__dict__
+
+
+# ---------------------------------------------------------------------------
+# Wrong decorator order detection (issue #251)
+# ---------------------------------------------------------------------------
+
+
+class TestWrongDecoratorOrder:
+    """@validate_http applied above @app.route must warn, not silently no-op."""
+
+    def test_function_builder_by_method_signal_warns_and_returns_unwrapped(self) -> None:
+        """An object exposing ``configure_function_builder`` is treated as a builder."""
+
+        class FakeBuilder:
+            def configure_function_builder(self) -> None:  # pragma: no cover - marker only
+                ...
+
+        builder = FakeBuilder()
+        with pytest.warns(RuntimeWarning, match=r"@app\.route"):
+            result = validate_http(body=UserModel)(builder)
+        assert result is builder
+
+    def test_function_builder_by_type_name_fallback_warns(self) -> None:
+        """SDK builds without the method are still caught by the type-name fallback."""
+
+        class FunctionBuilder:  # name is the fallback signal
+            pass
+
+        builder = FunctionBuilder()
+        with pytest.warns(RuntimeWarning, match="FunctionBuilder"):
+            result = validate_http(body=UserModel)(builder)
+        assert result is builder
+
+    def test_normal_handler_is_not_flagged(self, recwarn: pytest.WarningsRecorder) -> None:
+        """A normal handler must wrap without emitting the wrong-order warning."""
+
+        def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
+            return HttpResponse("ok")
+
+        wrapped = validate_http(body=UserModel)(handler)
+        assert wrapped is not handler
+        assert not any(
+            issubclass(w.category, RuntimeWarning) for w in recwarn.list
+        )


### PR DESCRIPTION
## Summary
- `@validate_http` above `@app.route` received a `FunctionBuilder` and returned it unwrapped with no signal — validation silently off.
- Add `_is_function_builder` detection via `configure_function_builder` (robust) with a type-name fallback, and emit a `RuntimeWarning` pointing users to the correct order.
- Normal handlers are unaffected (no false positives).

## Test
- New `TestWrongDecoratorOrder`: method-signal warns, type-name fallback warns, normal handler not flagged.
- Full suite green; coverage 98.2%.

Closes #251