### PR TITLE
feat(api): export ValidationAdapter and PydanticAdapter

### DIFF
--- a/src/azure_functions_validation/__init__.py
+++ b/src/azure_functions_validation/__init__.py
@@ -1,5 +1,6 @@
 """azure-functions-validation package."""
 
+from .adapter import PydanticAdapter, ValidationAdapter
 from .decorator import validate_http
 from .errors import ErrorFormatter, ResponseValidationError, SerializationError
 
@@ -9,6 +10,8 @@ __all__ = [
     "ResponseValidationError",
     "SerializationError",
     "ErrorFormatter",
+    "ValidationAdapter",
+    "PydanticAdapter",
 ]
 
 __version__ = "0.7.7"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -29,6 +29,8 @@ class TestAPISurface:
             "ResponseValidationError",
             "SerializationError",
             "ErrorFormatter",
+            "ValidationAdapter",
+            "PydanticAdapter",
         }
 
     def test_version_matches_distribution_metadata(self) -> None:


### PR DESCRIPTION
## Summary
- Export `ValidationAdapter` (protocol) and `PydanticAdapter` (default implementation) from the package root.
- Keep `__all__` and the public-API surface test in sync.

## Why
Consumers currently have to reach into the private `adapter` module to type against or reuse the validation adapter. Exporting these makes the extension point part of the supported public API.

## Testing
- `hatch run pytest --cov --cov-report=term-missing -q` — total coverage 97.72% (gate 95%).
- Pre-existing unrelated failure: `test_all_readme_variants_have_identical_quickstart` (README variant drift, tracked separately).

Closes #252