### PR TITLE
build: pin azure-functions>=1.17 and drop optional-import rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - Any PR that drops coverage below 95% must include additional tests to compensate.
 - Runtime code must remain compatible with Python 3.10+.
 - Public APIs must be fully typed.
-- No runtime dependency on `azure-functions` beyond what is required for type hints — keep imports optional where possible.
+- `azure-functions` (>=1.17) is a required runtime dependency; import it directly. This library only runs inside an Azure Functions app, where the package is always present.
 - Keep documentation examples, decorator behaviour, and tests synchronized.
 - The version test in `tests/test_public_api.py` reads from `importlib.metadata` and needs no manual edits across releases.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "azure-functions",
+    "azure-functions>=1.17",
     "pydantic>=2.0,<3.0",
 ]
 


### PR DESCRIPTION
## Summary
- Pin `azure-functions>=1.17` in `pyproject.toml` to match the v2 programming-model baseline.
- Remove the aspirational "keep azure-functions imports optional / no runtime dependency beyond type hints" rule from `AGENTS.md`.

## Why
The library only runs inside an Azure Functions app, where `azure-functions` is always installed. The old rule contradicted reality — `adapter.py`, `errors.py`, and `pipeline.py` all hard-import from `azure.functions` at module load. Those direct imports are correct; no lazy-import gymnastics exist that were justified only by the deleted rule.

## Testing
- `hatch run pytest --cov -q` — 97.71% coverage (gate 95%), 211 passed.
- `hatch build` — sdist + wheel build cleanly.
- Pre-existing unrelated failure: `test_all_readme_variants_have_identical_quickstart` (README variant drift, tracked separately).

Closes #253