### PR TITLE
feat(decorator): support status_code and public HttpError

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -119,6 +119,63 @@ def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserRes
     return CreateUserResponse(message=f"Hello {body.name}")
 ```
 
+## ステータスコードと制御されたエラー
+
+バリデーションをバイパスせずに、作成時に `201` を返したり、制御された HTTP エラー
+（例：`404`）を発生させたりできます。`status_code=` で成功時のステータスを指定し、
+`HttpError` を発生させると、標準の `{"detail": [...]}` 形式でエラーがレンダリングされます：
+
+```python
+import azure.functions as func
+from pydantic import BaseModel
+
+from azure_functions_validation import HttpError, validate_http
+
+app = func.FunctionApp()
+
+_USERS: dict[int, "UserResponse"] = {}
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+    email: str
+
+
+class UserResponse(BaseModel):
+    id: int
+    name: str
+
+
+@app.route(route="users", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(body=CreateUserRequest, response_model=UserResponse, status_code=201)
+def create_user(req: func.HttpRequest, body: CreateUserRequest) -> UserResponse:
+    user = UserResponse(id=len(_USERS) + 1, name=body.name)
+    _USERS[user.id] = user
+    return user  # HTTP 201
+
+
+@app.route(route="users/{user_id}", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(response_model=UserResponse)
+def get_user(req: func.HttpRequest) -> UserResponse:
+    user = _USERS.get(int(req.route_params["user_id"]))
+    if user is None:
+        raise HttpError(404, "User not found")  # 標準エラー形式
+    return user
+```
+
+存在しないユーザーには一貫したエラーボディが返されます：
+
+```json
+{"detail": [{"loc": [], "msg": "User not found", "type": "http_error"}]}
+```
+
+> HTTP 404
+
+`HttpError` はより詳細なエラーのために事前に構築された `detail` リストも受け付けます。また、
+サーバーサイド（`>=500`）のエラーは常にサニタイズされ、内部の詳細がクライアントに
+漏れることはありません。
+
+
 ## Documentation
 
 - プロジェクトドキュメント: `docs/`

--- a/README.ko.md
+++ b/README.ko.md
@@ -119,6 +119,63 @@ def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserRes
     return CreateUserResponse(message=f"Hello {body.name}")
 ```
 
+## 상태 코드와 제어된 오류
+
+검증을 우회하지 않고도 생성 시 `201`을 반환하거나 제어된 HTTP 오류(예: `404`)를
+발생시킬 수 있습니다. `status_code=`로 성공 상태 코드를 지정하고, `HttpError`를
+발생시키면 표준 `{"detail": [...]}` 형식으로 오류가 렌더링됩니다:
+
+```python
+import azure.functions as func
+from pydantic import BaseModel
+
+from azure_functions_validation import HttpError, validate_http
+
+app = func.FunctionApp()
+
+_USERS: dict[int, "UserResponse"] = {}
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+    email: str
+
+
+class UserResponse(BaseModel):
+    id: int
+    name: str
+
+
+@app.route(route="users", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(body=CreateUserRequest, response_model=UserResponse, status_code=201)
+def create_user(req: func.HttpRequest, body: CreateUserRequest) -> UserResponse:
+    user = UserResponse(id=len(_USERS) + 1, name=body.name)
+    _USERS[user.id] = user
+    return user  # HTTP 201
+
+
+@app.route(route="users/{user_id}", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(response_model=UserResponse)
+def get_user(req: func.HttpRequest) -> UserResponse:
+    user = _USERS.get(int(req.route_params["user_id"]))
+    if user is None:
+        raise HttpError(404, "User not found")  # 표준 오류 형식
+    return user
+```
+
+존재하지 않는 사용자는 일관된 오류 본문을 반환합니다:
+
+```json
+{"detail": [{"loc": [], "msg": "User not found", "type": "http_error"}]}
+```
+
+> HTTP 404
+
+`HttpError`는 더 풍부한 오류를 위해 미리 구성된 `detail` 리스트도 받을 수 있으며,
+서버 측(`>=500`) 오류는 항상 정제되어 내부 세부 정보가 클라이언트로 노출되지
+않습니다.
+
+
 ## Documentation
 
 - 프로젝트 문서: `docs/`

--- a/README.md
+++ b/README.md
@@ -331,6 +331,62 @@ curl -s "https://<your-app>.azurewebsites.net/api/users" \
 
 > Manually verified by maintainers against a temporary Azure Functions deployment (koreacentral, Python 3.12, Consumption plan); response captured and URL anonymized. See [docs/deployment.md](docs/deployment.md#verification-status) for the verification status and context.
 
+## Status codes and controlled errors
+
+Return `201` on creation and raise controlled HTTP errors (e.g. `404`) without
+bypassing validation. Set the success status with `status_code=` and raise
+`HttpError` to render an error through the standard `{"detail": [...]}` envelope:
+
+```python
+import azure.functions as func
+from pydantic import BaseModel
+
+from azure_functions_validation import HttpError, validate_http
+
+app = func.FunctionApp()
+
+_USERS: dict[int, "UserResponse"] = {}
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+    email: str
+
+
+class UserResponse(BaseModel):
+    id: int
+    name: str
+
+
+@app.route(route="users", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(body=CreateUserRequest, response_model=UserResponse, status_code=201)
+def create_user(req: func.HttpRequest, body: CreateUserRequest) -> UserResponse:
+    user = UserResponse(id=len(_USERS) + 1, name=body.name)
+    _USERS[user.id] = user
+    return user  # HTTP 201
+
+
+@app.route(route="users/{user_id}", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(response_model=UserResponse)
+def get_user(req: func.HttpRequest) -> UserResponse:
+    user = _USERS.get(int(req.route_params["user_id"]))
+    if user is None:
+        raise HttpError(404, "User not found")  # standardized error envelope
+    return user
+```
+
+A missing user returns a consistent error body:
+
+```json
+{"detail": [{"loc": [], "msg": "User not found", "type": "http_error"}]}
+```
+
+> HTTP 404
+
+`HttpError` also accepts a pre-built `detail` list for richer errors, and
+server-side (`>=500`) errors are always sanitized so internal details never
+leak to clients.
+
 ## When to use
 
 - You have HTTP-triggered Azure Functions that accept JSON request bodies

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,6 +119,62 @@ def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserRes
     return CreateUserResponse(message=f"Hello {body.name}")
 ```
 
+## 状态码与受控错误
+
+无需绕过验证即可在创建时返回 `201`，或抛出受控的 HTTP 错误（例如 `404`）。
+使用 `status_code=` 设置成功状态码，并抛出 `HttpError` 以标准
+`{"detail": [...]}` 格式渲染错误：
+
+```python
+import azure.functions as func
+from pydantic import BaseModel
+
+from azure_functions_validation import HttpError, validate_http
+
+app = func.FunctionApp()
+
+_USERS: dict[int, "UserResponse"] = {}
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+    email: str
+
+
+class UserResponse(BaseModel):
+    id: int
+    name: str
+
+
+@app.route(route="users", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(body=CreateUserRequest, response_model=UserResponse, status_code=201)
+def create_user(req: func.HttpRequest, body: CreateUserRequest) -> UserResponse:
+    user = UserResponse(id=len(_USERS) + 1, name=body.name)
+    _USERS[user.id] = user
+    return user  # HTTP 201
+
+
+@app.route(route="users/{user_id}", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(response_model=UserResponse)
+def get_user(req: func.HttpRequest) -> UserResponse:
+    user = _USERS.get(int(req.route_params["user_id"]))
+    if user is None:
+        raise HttpError(404, "User not found")  # 标准错误格式
+    return user
+```
+
+不存在的用户会返回一致的错误体：
+
+```json
+{"detail": [{"loc": [], "msg": "User not found", "type": "http_error"}]}
+```
+
+> HTTP 404
+
+`HttpError` 还可接受预先构建的 `detail` 列表以表达更丰富的错误，而服务端
+（`>=500`）错误始终会被清理，因此内部细节绝不会泄露给客户端。
+
+
 ## Documentation
 
 - 项目文档位于 `docs/`

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,6 +49,52 @@ def create_invoice(req: func.HttpRequest, body: CreateInvoiceBody) -> CreateInvo
     return CreateInvoiceResponse(invoice_id="inv_1001", status="created")
 ```
 
+### Usage example: status codes and controlled errors
+
+Use `status_code=` to set the success status (e.g. `201` for creation), and
+raise `HttpError` to return a controlled error through the standard
+`{"detail": [...]}` envelope without bypassing validation.
+
+```python
+import azure.functions as func
+from pydantic import BaseModel
+
+from azure_functions_validation import HttpError, validate_http
+
+
+class CreateUserBody(BaseModel):
+    name: str
+
+
+class UserResponse(BaseModel):
+    id: int
+    name: str
+
+
+app = func.FunctionApp()
+
+_USERS: dict[int, UserResponse] = {}
+
+
+@app.function_name(name="create_user")
+@app.route(route="users", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(body=CreateUserBody, response_model=UserResponse, status_code=201)
+def create_user(req: func.HttpRequest, body: CreateUserBody) -> UserResponse:
+    user = UserResponse(id=len(_USERS) + 1, name=body.name)
+    _USERS[user.id] = user
+    return user  # HTTP 201
+
+
+@app.function_name(name="get_user")
+@app.route(route="users/{user_id}", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@validate_http(response_model=UserResponse)
+def get_user(req: func.HttpRequest) -> UserResponse:
+    user = _USERS.get(int(req.route_params["user_id"]))
+    if user is None:
+        raise HttpError(404, "User not found")
+    return user
+```
+
 ### Usage example: query + path + headers
 
 ```python
@@ -204,6 +250,16 @@ def custom_error(req: func.HttpRequest, body: InputModel) -> dict[str, int]:
 
 !!! tip "Formatter signature"
     Keep the formatter signature exactly `(exc: Exception, status_code: int) -> dict[str, Any]`.
+
+## `HttpError`
+
+::: azure_functions_validation.HttpError
+
+Raise `HttpError(status_code, detail)` from a handler to return a controlled
+HTTP error rendered through the standard `{"detail": [...]}` envelope. `detail`
+may be a plain message (wrapped into a single entry) or a pre-built list of
+`{"loc", "msg", "type"}` mappings. Errors with `status_code >= 500` are
+sanitized so internal details never leak to clients.
 
 ## Error response shape reference
 

--- a/src/azure_functions_validation/__init__.py
+++ b/src/azure_functions_validation/__init__.py
@@ -1,7 +1,7 @@
 """azure-functions-validation package."""
 
 from .decorator import validate_http
-from .errors import ErrorFormatter, ResponseValidationError, SerializationError
+from .errors import ErrorFormatter, HttpError, ResponseValidationError, SerializationError
 
 __all__ = [
     "__version__",
@@ -9,6 +9,7 @@ __all__ = [
     "ResponseValidationError",
     "SerializationError",
     "ErrorFormatter",
+    "HttpError",
 ]
 
 __version__ = "0.7.7"

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -25,6 +25,7 @@ def validate_http(
     response_model: Any = None,
     adapter: ValidationAdapter | None = None,
     error_formatter: ErrorFormatter | None = None,
+    status_code: int = 200,
 ) -> Callable[..., Any]:
     """Decorator for validating HTTP request inputs and response outputs.
 
@@ -38,6 +39,8 @@ def validate_http(
         response_model: Pydantic model for response validation.
         adapter: Custom validation adapter (defaults to ``PydanticAdapter``).
         error_formatter: Per-handler custom error formatter.
+        status_code: HTTP status code for successful responses (default 200).
+            Use e.g. ``status_code=201`` for creation endpoints.
 
     Returns:
         A decorator that wraps the handler with validation logic.
@@ -86,6 +89,7 @@ def validate_http(
             func_params=func_params,
             request_param_name=request_param_name,
             response_type_adapter=response_type_adapter,
+            success_status_code=status_code,
         )
 
         wrapper = _make_wrapper(func, config, is_async=is_async)

--- a/src/azure_functions_validation/errors.py
+++ b/src/azure_functions_validation/errors.py
@@ -53,7 +53,41 @@ class SerializationError(TypeError):
         """
         super().__init__(f"Cannot serialize type {type_name}")
         self.type_name = type_name
+        self.type_name = type_name
 
+
+class HttpError(Exception):
+    """Raised by a handler to return a controlled HTTP error response.
+
+    Rendered through the standard error envelope (``{"detail": [...]}``) by the
+    validation pipeline, so controlled errors (e.g. 404, 409) share the same
+    shape as automatic validation errors.
+
+    Args:
+        status_code: HTTP status code for the response (e.g. ``404``).
+        detail: Either a human-readable message (wrapped into a single
+            ``{"loc": [], "msg": ..., "type": ...}`` entry) or a pre-built list
+            of detail mappings matching the error-envelope schema.
+        error_type: ``type`` value used when *detail* is a plain message.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        detail: Any = "Error",
+        *,
+        error_type: str = "http_error",
+    ) -> None:
+        super().__init__(str(detail))
+        self.status_code = status_code
+        self.detail = detail
+        self.error_type = error_type
+
+    def to_detail(self) -> list[dict[str, Any]]:
+        """Return the error-envelope ``detail`` list for this error."""
+        if isinstance(self.detail, list):
+            return self.detail
+        return [{"loc": [], "msg": str(self.detail), "type": self.error_type}]
 
 class AdapterValidationError(Exception):
     """Raised by validation adapters when request/response validation fails.
@@ -102,6 +136,9 @@ def format_error_response(
             response_status_code = 500
 
             error_response = json.loads(_SANITIZED_500_BODY)
+    elif isinstance(exception, HttpError) and status_code < 500:
+        # Controlled handler error — render its detail through the envelope.
+        error_response = {"detail": exception.to_detail()}
     elif status_code >= 500:
         # Sanitize server errors — never leak internal details to the client
         error_response = json.loads(_SANITIZED_500_BODY)

--- a/src/azure_functions_validation/pipeline.py
+++ b/src/azure_functions_validation/pipeline.py
@@ -17,6 +17,7 @@ from .adapter import PydanticAdapter, ValidationAdapter
 from .errors import (
     AdapterValidationError,
     ErrorFormatter,
+    HttpError,
     ResponseValidationError,
     SerializationError,
     format_error_response,
@@ -42,6 +43,7 @@ class PipelineConfig:
     func_params: Mapping[str, Any] = field(default_factory=dict)
     request_param_name: str | None = None
     response_type_adapter: Any = None
+    success_status_code: int = 200
 
 
 # ---------------------------------------------------------------------------
@@ -81,7 +83,12 @@ def run_pipeline(
     early, merged = _prepare_invocation(args, kwargs, config)
     if early is not None:
         return early
-    result = func(*args, **merged) if args else func(**merged)
+    try:
+        result = func(*args, **merged) if args else func(**merged)
+    except HttpError as e:
+        return format_error_response(
+            e, e.status_code, config.adapter, config.error_formatter
+        )
     return _build_response(result, config)
 
 
@@ -95,7 +102,12 @@ async def run_pipeline_async(
     early, merged = _prepare_invocation(args, kwargs, config)
     if early is not None:
         return early
-    result = await (func(*args, **merged) if args else func(**merged))
+    try:
+        result = await (func(*args, **merged) if args else func(**merged))
+    except HttpError as e:
+        return format_error_response(
+            e, e.status_code, config.adapter, config.error_formatter
+        )
     return _build_response(result, config)
 
 
@@ -256,7 +268,9 @@ def _build_response(result: Any, config: PipelineConfig) -> HttpResponse:
             )
 
         return HttpResponse(
-            body=content, status_code=200, headers={"Content-Type": content_type}
+            body=content,
+            status_code=config.success_status_code,
+            headers={"Content-Type": content_type},
         )
 
     # No response model, serialize directly
@@ -269,6 +283,6 @@ def _build_response(result: Any, config: PipelineConfig) -> HttpResponse:
 
     return HttpResponse(
         body=content,
-        status_code=200,
+        status_code=config.success_status_code,
         headers={"Content-Type": content_type},
     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -957,3 +957,114 @@ class TestErrorPathNormalization:
         assert response.status_code == 500
         data = json.loads(response.get_body().decode())
         assert "detail" in data
+
+
+
+# ---------------------------------------------------------------------------
+# Success status_code + public HttpError (Issue #254)
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessStatusCode:
+    """``status_code=`` overrides the default 200 on the success path."""
+
+    def test_status_code_applies_with_response_model(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        @validate_http(body=UserModel, response_model=ResponseModel, status_code=201)
+        def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
+            return ResponseModel(message=f"created {body.name}")
+
+        response = handler(mock_request_factory(body=b'{"name": "Alice", "age": 30}'))
+        assert response.status_code == 201
+        data = json.loads(response.get_body().decode())
+        assert data["message"] == "created Alice"
+
+    def test_status_code_applies_without_response_model(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        @validate_http(body=UserModel, status_code=202)
+        def handler(req: HttpRequest, body: UserModel) -> dict[str, str]:
+            return {"name": body.name}
+
+        response = handler(mock_request_factory(body=b'{"name": "Bob", "age": 40}'))
+        assert response.status_code == 202
+
+    def test_default_status_code_is_200(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        @validate_http(body=UserModel, response_model=ResponseModel)
+        def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
+            return ResponseModel(message="ok")
+
+        response = handler(mock_request_factory(body=b'{"name": "Cara", "age": 22}'))
+        assert response.status_code == 200
+
+
+class TestHttpError:
+    """Public ``HttpError`` renders through the standard error envelope."""
+
+    def test_http_error_returns_status_and_envelope(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        from azure_functions_validation import HttpError
+
+        @validate_http(body=UserModel)
+        def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
+            raise HttpError(404, "User not found")
+
+        response = handler(mock_request_factory(body=b'{"name": "Dan", "age": 33}'))
+        assert response.status_code == 404
+        data = json.loads(response.get_body().decode())
+        assert data["detail"] == [
+            {"loc": [], "msg": "User not found", "type": "http_error"}
+        ]
+
+    def test_http_error_accepts_structured_detail(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        from azure_functions_validation import HttpError
+
+        detail = [{"loc": ["body", "name"], "msg": "taken", "type": "conflict"}]
+
+        @validate_http(body=UserModel)
+        def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
+            raise HttpError(409, detail)
+
+        response = handler(mock_request_factory(body=b'{"name": "Eve", "age": 27}'))
+        assert response.status_code == 409
+        data = json.loads(response.get_body().decode())
+        assert data["detail"] == detail
+
+    def test_http_error_5xx_is_sanitized(
+        self, mock_request_factory: RequestFactory,
+    ) -> None:
+        from azure_functions_validation import HttpError
+
+        @validate_http(body=UserModel)
+        def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
+            raise HttpError(503, "database down: secret-host:5432")
+
+        response = handler(mock_request_factory(body=b'{"name": "Fay", "age": 44}'))
+        assert response.status_code == 503
+        data = json.loads(response.get_body().decode())
+        # Internal detail must not leak on server errors.
+        assert data["detail"][0]["msg"] == "Internal Server Error"
+        assert "secret-host" not in json.dumps(data)
+
+    @pytest.mark.anyio
+    async def test_async_http_error(
+        self, mock_request_factory: RequestFactory
+    ) -> None:
+        from azure_functions_validation import HttpError
+
+        @validate_http(body=UserModel)
+        async def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
+            raise HttpError(404, "missing")
+
+        response = await handler(
+            mock_request_factory(body=b'{"name": "Gus", "age": 51}')
+        )
+        assert response.status_code == 404
+        data = json.loads(response.get_body().decode())
+        assert data["detail"][0]["msg"] == "missing"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -10,6 +10,7 @@ import pytest
 import azure_functions_validation
 from azure_functions_validation import (
     ErrorFormatter,
+    HttpError,
     ResponseValidationError,
     validate_http,
 )
@@ -29,6 +30,7 @@ class TestAPISurface:
             "ResponseValidationError",
             "SerializationError",
             "ErrorFormatter",
+            "HttpError",
         }
 
     def test_version_matches_distribution_metadata(self) -> None:
@@ -350,3 +352,11 @@ class TestTypeExports:
     def test_response_validation_error_str(self) -> None:
         err = ResponseValidationError("test message")
         assert str(err) == "test message"
+
+    def test_http_error_carries_status_and_detail(self) -> None:
+        err = HttpError(404, "missing")
+        assert isinstance(err, Exception)
+        assert err.status_code == 404
+        assert err.to_detail() == [
+            {"loc": [], "msg": "missing", "type": "http_error"}
+        ]


### PR DESCRIPTION
## Summary
- Add `status_code=` to `validate_http()` so handlers can return non-200 success codes (e.g. `201` on creation) — applied on both the response-model and no-response-model success paths.
- Add a public `HttpError(status_code, detail)` exception. The pipeline catches it (sync + async) and renders it through the standard `{"detail": [...]}` error envelope, so controlled errors (404, 409, …) match automatic validation errors.
- `detail` accepts a plain message (wrapped into one entry) or a pre-built list of `{loc, msg, type}` mappings.
- Server-side (`>=500`) `HttpError`s are sanitized — internal details never leak.
- Export `HttpError` from the package root; document both features with a CRUD example in the README (+ ko/ja/zh-CN translations) and `docs/api.md`.

## Why
Handlers returning a model always yielded HTTP 200 with no way to express 201/404 without bypassing validation via a raw `HttpResponse`. This blocked any non-trivial CRUD API.

## Testing
- `make lint` — clean.
- `make typecheck` — clean (21 files).
- `make build` — sdist + wheel OK.
- `hatch run pytest --cov -q` — 97.83% coverage; new tests cover 201 success, 404 via `HttpError`, structured detail, 5xx sanitization, async path, and the public export.
- Pre-existing unrelated failure: `test_all_readme_variants_have_identical_quickstart` (README Quick Start variant drift, tracked separately — untouched by this PR).

Closes #254