### PR TITLE
refactor(adapter): hoist missing-body model to module constant

### DIFF
--- a/src/azure_functions_validation/adapter.py
+++ b/src/azure_functions_validation/adapter.py
@@ -172,15 +172,11 @@ class PydanticAdapter:
 
     @staticmethod
     def _missing_body_validation_error() -> AdapterValidationError:
-        class _MissingBodyPayload(BaseModel):
-            body: Any
-
-        try:
-            _MissingBodyPayload.model_validate({})
-        except PydanticValidationError as exc:
-            return PydanticAdapter._to_adapter_error(exc)
-
-        raise RuntimeError("Unreachable: expected missing body validation error")
+        # The underlying Pydantic model and its validation error are built once
+        # at import time (see ``_MISSING_BODY_ERROR`` below).  A fresh exception
+        # is returned per call so callers never share mutable error state.
+        message, detail = _MISSING_BODY_ERROR
+        return AdapterValidationError(message, [dict(entry) for entry in detail])
 
     def parse_body(self, req: HttpRequest, model: type[BaseModel]) -> Any:
         """Parse and validate request body from JSON.
@@ -380,3 +376,29 @@ class PydanticAdapter:
                     }
                 ]
             }
+
+
+
+def _compute_missing_body_error() -> tuple[str, list[dict[str, Any]]]:
+    """Build the missing-body validation error once, at import time.
+
+    Creating a Pydantic model class is relatively expensive; hoisting it out of
+    the per-request hot path avoids re-creating it on every empty-body request.
+    The resulting ``(message, detail)`` pair is reused to construct fresh
+    :class:`AdapterValidationError` instances with identical ``loc``/``msg``/
+    ``type`` output.
+    """
+
+    class _MissingBodyPayload(BaseModel):
+        body: Any
+
+    try:
+        _MissingBodyPayload.model_validate({})
+    except PydanticValidationError as exc:
+        adapter_error = PydanticAdapter._to_adapter_error(exc)
+        return str(exc), adapter_error.errors
+
+    raise RuntimeError("Unreachable: expected missing body validation error")
+
+
+_MISSING_BODY_ERROR: tuple[str, list[dict[str, Any]]] = _compute_missing_body_error()

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -87,6 +87,28 @@ class TestParseBody:
         assert errors[0]["type"] == "missing"
         assert errors[0]["loc"] == ["body"]
 
+    def test_missing_body_error_is_stable_and_isolated(
+        self, adapter: PydanticAdapter, mock_request: type
+    ) -> None:
+        """Repeated empty-body parses yield identical but independent errors."""
+        errors = []
+        for _ in range(2):
+            with pytest.raises(AdapterValidationError) as exc_info:
+                adapter.parse_body(mock_request(b""), UserModel)
+            errors.append(exc_info.value.errors)
+
+        # Identical normalized output across calls (hoisted, not regenerated).
+        assert errors[0] == errors[1]
+        assert errors[0] == [
+            {"loc": ["body"], "msg": "Field required", "type": "missing"}
+        ]
+        # Fresh list per call — mutating one must not affect the next.
+        assert errors[0] is not errors[1]
+        errors[0].append({"tampered": True})
+        with pytest.raises(AdapterValidationError) as exc_info:
+            adapter.parse_body(mock_request(b""), UserModel)
+        assert len(exc_info.value.errors) == 1
+
     def test_invalid_json(self, adapter: PydanticAdapter, mock_request: type) -> None:
         """Test parsing invalid JSON raises ValueError."""
         req = mock_request(b"{invalid json}")


### PR DESCRIPTION
## Summary
- Build the `_MissingBodyPayload` model and its normalized validation error once at import time (`_MISSING_BODY_ERROR`) instead of re-creating the model class on every empty-body request.
- `_missing_body_validation_error()` now returns a fresh `AdapterValidationError` per call, copying the detail list so callers never share mutable state.

## Why
Defining a Pydantic model class inside the hot path is a needless per-request allocation. Error output (`loc`/`msg`/`type`) is identical.

## Testing
- `make lint`, `make typecheck` — clean.
- `hatch run pytest --cov -q` — 97.74% coverage.
- Added `test_missing_body_error_is_stable_and_isolated`: identical output across calls + independent instances (mutating one error list does not affect the next). Existing `test_empty_body` / `test_whitespace_body_is_treated_as_missing` still pass.

Closes #255