### PR TITLE
feat(errors): add error_format_version stability field to error envelope

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -217,6 +217,33 @@ Default validation and parsing errors use this envelope:
       "msg": "Field required",
       "type": "missing"
     }
+  ],
+  "error_format_version": 1
+}
+```
+
+### Stability contract
+
+Every **default** error envelope carries a top-level `error_format_version`
+integer. It lets downstream consumers (frontends, API gateways) pin against a
+known schema and detect breaking changes explicitly instead of silently
+misparsing new fields.
+
+- The current version is `1`.
+- The integer is bumped **only** when the default envelope changes in a
+  backwards-incompatible way; additive, optional fields do not bump it.
+- The marker is present on all built-in envelopes — validation errors (`4xx`),
+  sanitized server errors (`5xx`), and the internal-failure fallback.
+- A **custom** `ErrorFormatter` owns its output shape entirely: the marker is
+  never injected into a successful custom formatter's response. Emit your own
+  version field there if you need one.
+{
+  "detail": [
+    {
+      "loc": ["body", "field_name"],
+      "msg": "Field required",
+      "type": "missing"
+    }
   ]
 }
 ```

--- a/src/azure_functions_validation/errors.py
+++ b/src/azure_functions_validation/errors.py
@@ -12,6 +12,11 @@ logger = logging.getLogger(__name__)
 
 ErrorFormatter = Callable[[Exception, int], dict[str, Any]]
 
+#: Stability marker embedded in every default error envelope.  Downstream
+#: consumers can pin against this integer; it is bumped only when the default
+#: error-response schema changes in a backwards-incompatible way.
+ERROR_FORMAT_VERSION = 1
+
 _SANITIZED_500_BODY = json.dumps(
     {
         "detail": [
@@ -93,6 +98,7 @@ def format_error_response(
         An ``HttpResponse`` with a JSON error body.
     """
     response_status_code = status_code
+    used_custom_formatter = False
 
     if error_formatter is not None:
         try:
@@ -102,11 +108,18 @@ def format_error_response(
             response_status_code = 500
 
             error_response = json.loads(_SANITIZED_500_BODY)
+        else:
+            used_custom_formatter = True
     elif status_code >= 500:
         # Sanitize server errors — never leak internal details to the client
         error_response = json.loads(_SANITIZED_500_BODY)
     else:
         error_response = adapter.format_error(exception)
+
+    # Stamp the stability marker on every default envelope, but never mutate a
+    # successful custom formatter's output — callers own that shape entirely.
+    if not used_custom_formatter and isinstance(error_response, dict):
+        error_response.setdefault("error_format_version", ERROR_FORMAT_VERSION)
 
     try:
         body = json.dumps(error_response)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -7,6 +7,7 @@ from azure.functions import HttpResponse
 import pytest
 
 from azure_functions_validation.errors import (
+    ERROR_FORMAT_VERSION,
     ErrorFormatter,
     ResponseValidationError,
     SerializationError,
@@ -78,7 +79,7 @@ class TestFormatErrorResponse:
         assert isinstance(resp, HttpResponse)
         assert resp.status_code == 422
         data = json.loads(resp.get_body().decode())
-        assert data == {"detail": [{"msg": "oops"}]}
+        assert data == {"detail": [{"msg": "oops"}], "error_format_version": 1}
         adapter.format_error.assert_called_once_with(exc)
 
     def test_uses_custom_formatter(self) -> None:
@@ -113,7 +114,8 @@ class TestFormatErrorResponse:
         assert resp.status_code == 500
         data = json.loads(resp.get_body().decode())
         assert data == {
-            "detail": [{"loc": [], "msg": "Internal Server Error", "type": "server_error"}]
+            "detail": [{"loc": [], "msg": "Internal Server Error", "type": "server_error"}],
+            "error_format_version": 1,
         }
         adapter.format_error.assert_not_called()
 
@@ -146,12 +148,45 @@ class TestFormatErrorResponse:
         assert resp.status_code == 500
         data = json.loads(resp.get_body().decode())
         assert data == {
-            "detail": [{"loc": [], "msg": "Internal Server Error", "type": "server_error"}]
+            "detail": [{"loc": [], "msg": "Internal Server Error", "type": "server_error"}],
+            "error_format_version": 1,
         }
         adapter.format_error.assert_not_called()
         # Verify that the exception was logged
         assert "error_formatter raised an unexpected exception" in caplog.text
         assert caplog.records[0].levelname == "ERROR"
+
+    def test_default_envelope_carries_format_version(self) -> None:
+        """Every default envelope is stamped with the stability marker."""
+        adapter = Mock()
+        adapter.format_error.return_value = {"detail": [{"msg": "oops"}]}
+
+        resp = format_error_response(ValueError("oops"), 422, adapter)
+
+        data = json.loads(resp.get_body().decode())
+        assert data["error_format_version"] == ERROR_FORMAT_VERSION
+
+    def test_adapter_supplied_version_is_not_overwritten(self) -> None:
+        """An adapter that already sets the marker keeps its own value."""
+        adapter = Mock()
+        adapter.format_error.return_value = {"detail": [], "error_format_version": 99}
+
+        resp = format_error_response(ValueError("x"), 422, adapter)
+
+        data = json.loads(resp.get_body().decode())
+        assert data["error_format_version"] == 99
+
+    def test_custom_formatter_output_is_not_stamped(self) -> None:
+        """A successful custom formatter owns its shape — no marker injected."""
+        adapter = Mock()
+
+        def fmt(exc: Exception, status: int) -> dict[str, object]:
+            return {"custom": True}
+
+        resp = format_error_response(ValueError("x"), 400, adapter, error_formatter=fmt)
+
+        data = json.loads(resp.get_body().decode())
+        assert "error_format_version" not in data
 
     def test_non_serializable_error_response_returns_sanitized_500(
         self,


### PR DESCRIPTION
## Summary
- Stamp a top-level `error_format_version` integer (currently `1`) on every **default** error envelope — validation `4xx`, sanitized `5xx`, and the internal-failure fallback — so downstream consumers can pin against a known schema and detect breaking changes explicitly instead of silently misparsing new fields.
- A successful custom `ErrorFormatter` owns its output shape entirely: the marker is never injected there.
- Document the envelope schema and its stability contract in `docs/api.md`.

## Why
Precondition for the breaking `loc` source-prefix change (#257) and the `status_code`/`HttpError` work (#254). Without an explicit version marker, those envelope changes would silently break every consumer.

## Testing
- `make lint` ✅  `make typecheck` ✅  `make build` ✅
- `hatch run pytest --cov` → 97.75% (gate 95%), all pass except the pre-existing `test_all_readme_variants_have_identical_quickstart` failure that exists on `main` and is unrelated to this change.
- Added tests: default envelope carries version, adapter-supplied version not overwritten, custom-formatter output not stamped.

Closes #256