### PR TITLE
fix(errors): source-prefix error loc

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -67,11 +67,16 @@ All validation errors use a **stable** `{"detail": [...]}` envelope:
     {
       "loc": ["body", "email"],
       "msg": "value is not a valid email address",
-      "type": "value_error.email"
+      "type": "value_error"
     }
   ]
 }
 ```
+
+Each `loc` is prefixed with its input source (`body`, `query`, `path`, or
+`headers`) so collisions across sources stay distinguishable. Pass
+`legacy_loc=True` to `validate_http` for one release to opt out of the source
+prefix during migration.
 
 | HTTP status | Trigger |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ $ curl -s -X POST http://localhost:7071/api/users \
 {
   "detail": [
     {
-      "loc": ["email"],
+      "loc": ["body", "email"],
       "msg": "Field required",
       "type": "missing"
     }

--- a/docs/api.md
+++ b/docs/api.md
@@ -234,6 +234,13 @@ Common status codes:
     - header errors: `loc` starts with `"headers"`
     - response errors: `loc` equals `["response"]`
 
+!!! tip "Opting out of the source prefix"
+    The leading source segment (`body` / `query` / `path` / `headers`) was
+    added to disambiguate same-named fields across inputs. To keep the previous
+    unprefixed `loc` for one migration cycle, pass `legacy_loc=True` to
+    `validate_http`. This escape hatch will be removed in a future release.
+    - response errors: `loc` equals `["response"]`
+
 ## Internal references
 
 These modules are useful for advanced extension work but are internal APIs:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,29 @@ The changelog is generated from Conventional Commits using git-cliff. Breaking c
 
 ## Migration Guides
 
+### Error `loc` now carries an input-source prefix (upcoming minor)
+
+Validation error `loc` values are now prefixed with their input source, so a
+body field error reports `["body", "email"]` instead of `["email"]`. This
+disambiguates collisions across `body` / `query` / `path` / `headers` when the
+same field name appears in more than one source.
+
+- **Before:** `{"loc": ["email"], "msg": "Field required", "type": "missing"}`
+- **After:** `{"loc": ["body", "email"], "msg": "Field required", "type": "missing"}`
+
+If your clients parse `loc` positionally, update them to expect the leading
+source segment. For a one-release migration window, pass `legacy_loc=True` to
+`@validate_http` to restore the previous unprefixed shape:
+
+```python
+@validate_http(body=CreateUserRequest, legacy_loc=True)
+def create_user(req, body):
+    ...
+```
+
+`legacy_loc` is a temporary escape hatch and will be removed in a later release.
+
+
 ### Migrating from v0.3.0 to v0.5.0
 
 The v0.5.0 release significantly reduced the public API surface to focus on the core validation decorator.

--- a/src/azure_functions_validation/adapter.py
+++ b/src/azure_functions_validation/adapter.py
@@ -11,6 +11,19 @@ from pydantic import ValidationError as PydanticValidationError
 from .errors import AdapterValidationError, SerializationError
 
 
+def _prefix_loc(source: str | None, loc: list[Any], *, legacy_loc: bool) -> list[Any]:
+    """Prepend the input *source* segment to a Pydantic ``loc`` tuple.
+
+    Produces source-disambiguated locations such as ``["body", "email"]`` so
+    that body/query/path/header collisions are distinguishable.  When
+    *legacy_loc* is ``True`` (or *source* is ``None``) the raw ``loc`` is
+    returned unchanged for one-cycle backward compatibility.
+    """
+    if legacy_loc or source is None:
+        return loc
+    return [source, *loc]
+
+
 def _json_default(value: Any) -> Any:
     """Fallback JSON encoder for nested models/dataclasses inside dict/list."""
     if isinstance(value, BaseModel):
@@ -152,23 +165,48 @@ class ValidationAdapter(Protocol):
 class PydanticAdapter:
     """Concrete validation adapter implementation using Pydantic v2."""
 
+    def __init__(self, *, legacy_loc: bool = False) -> None:
+        """Initialize the adapter.
+
+        Args:
+            legacy_loc: When ``True``, error ``loc`` values are emitted without
+                the leading input-source segment (``["email"]`` instead of
+                ``["body", "email"]``).  This is a one-cycle migration escape
+                hatch and will be removed in a future release.
+        """
+        self._legacy_loc = legacy_loc
+
     @staticmethod
-    def _to_adapter_error(exc: PydanticValidationError) -> AdapterValidationError:
+    def _to_adapter_error(
+        exc: PydanticValidationError,
+        *,
+        source: str | None = None,
+        legacy_loc: bool = False,
+    ) -> AdapterValidationError:
         """Convert a Pydantic ``ValidationError`` into an ``AdapterValidationError``.
 
         The library-specific exception is preserved as ``__cause__`` while the
         normalized ``errors`` list keeps the pipeline and downstream callers
-        decoupled from Pydantic.
+        decoupled from Pydantic.  When *source* is provided, each ``loc`` is
+        prefixed with it (unless *legacy_loc* is set).
         """
         detail = [
             {
-                "loc": list(error["loc"]),
+                "loc": _prefix_loc(source, list(error["loc"]), legacy_loc=legacy_loc),
                 "msg": error["msg"],
                 "type": error["type"],
             }
             for error in exc.errors()
         ]
         return AdapterValidationError(str(exc), detail)
+
+    def _source_error(
+        self, exc: PydanticValidationError, source: str
+    ) -> AdapterValidationError:
+        """Convert *exc*, prefixing ``loc`` with *source* per ``legacy_loc``."""
+        return self._to_adapter_error(
+            exc, source=source, legacy_loc=self._legacy_loc
+        )
 
     @staticmethod
     def _missing_body_validation_error() -> AdapterValidationError:
@@ -221,7 +259,7 @@ class PydanticAdapter:
         try:
             return model.model_validate(data)
         except PydanticValidationError as exc:
-            raise self._to_adapter_error(exc) from exc
+            raise self._source_error(exc, "body") from exc
 
     def parse_query(self, req: HttpRequest, model: type[BaseModel]) -> Any:
         """Parse and validate query parameters.
@@ -248,7 +286,7 @@ class PydanticAdapter:
         try:
             return model.model_validate(query_data)
         except PydanticValidationError as exc:
-            raise self._to_adapter_error(exc) from exc
+            raise self._source_error(exc, "query") from exc
 
     def parse_path(self, req: HttpRequest, model: type[BaseModel]) -> Any:
         """Parse and validate path parameters.
@@ -270,7 +308,7 @@ class PydanticAdapter:
         try:
             return model.model_validate(route_params)
         except PydanticValidationError as exc:
-            raise self._to_adapter_error(exc) from exc
+            raise self._source_error(exc, "path") from exc
 
     def parse_headers(self, req: HttpRequest, model: type[BaseModel]) -> Any:
         """Parse and validate headers.
@@ -297,7 +335,7 @@ class PydanticAdapter:
         try:
             return model.model_validate(header_data)
         except PydanticValidationError as exc:
-            raise self._to_adapter_error(exc) from exc
+            raise self._source_error(exc, "headers") from exc
 
     def validate_response(
         self, obj: Any, model: Any,
@@ -326,7 +364,7 @@ class PydanticAdapter:
         try:
             return ta.validate_python(obj)
         except PydanticValidationError as exc:
-            raise self._to_adapter_error(exc) from exc
+            raise self._source_error(exc, "response") from exc
 
     def serialize(self, obj: Any) -> tuple[str | bytes, str]:
         """Serialize response object to content and content-type.

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -25,6 +25,7 @@ def validate_http(
     response_model: Any = None,
     adapter: ValidationAdapter | None = None,
     error_formatter: ErrorFormatter | None = None,
+    legacy_loc: bool = False,
 ) -> Callable[..., Any]:
     """Decorator for validating HTTP request inputs and response outputs.
 
@@ -37,6 +38,11 @@ def validate_http(
             passing ``request_model`` emits a ``DeprecationWarning``.
         response_model: Pydantic model for response validation.
         adapter: Custom validation adapter (defaults to ``PydanticAdapter``).
+        error_formatter: Per-handler custom error formatter.
+        legacy_loc: When ``True``, error ``loc`` values omit the leading
+            input-source segment (``["email"]`` instead of ``["body", "email"]``).
+            A one-cycle migration escape hatch; ignored when a custom *adapter*
+            is supplied (configure that adapter directly).
         error_formatter: Per-handler custom error formatter.
 
     Returns:
@@ -56,6 +62,8 @@ def validate_http(
         body = request_model
 
     # Use default adapter if none provided
+    if adapter is None:
+        adapter = PydanticAdapter(legacy_loc=legacy_loc)
     if adapter is None:
         adapter = PydanticAdapter()
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -266,6 +266,84 @@ class TestRequestParsing:
         assert result.user_id == 1
 
 
+# Test loc source-prefixing (#257)
+class TestLocSourcePrefix:
+    """Error ``loc`` values carry their input-source segment."""
+
+    def test_body_error_loc_is_prefixed(
+        self, adapter: PydanticAdapter, mock_request: type
+    ) -> None:
+        req = mock_request(b'{"name": "Al", "age": 30}')
+        with pytest.raises(AdapterValidationError) as exc_info:
+            adapter.parse_body(req, UserModel)
+
+        loc = exc_info.value.errors[0]["loc"]
+        assert loc[0] == "body"
+        assert "name" in loc
+
+    def test_query_error_loc_is_prefixed(self, adapter: PydanticAdapter) -> None:
+        class QueryOnly(BaseModel):
+            count: int
+
+        class Request:
+            params = {"count": "not-an-int"}
+
+        with pytest.raises(AdapterValidationError) as exc_info:
+            adapter.parse_query(cast(Any, Request()), QueryOnly)
+
+        assert exc_info.value.errors[0]["loc"][0] == "query"
+
+    def test_path_error_loc_is_prefixed(self, adapter: PydanticAdapter) -> None:
+        class PathModel(BaseModel):
+            user_id: int
+
+        request = func.HttpRequest(
+            method="GET",
+            url="/api/users/x",
+            body=b"",
+            params={},
+            headers={},
+            route_params={"user_id": "not-a-number"},
+        )
+        with pytest.raises(AdapterValidationError) as exc_info:
+            adapter.parse_path(request, PathModel)
+
+        assert exc_info.value.errors[0]["loc"][0] == "path"
+
+    def test_headers_error_loc_is_prefixed(self, adapter: PydanticAdapter) -> None:
+        class HeaderOnly(BaseModel):
+            model_config = ConfigDict(populate_by_name=True)
+
+            request_id: str = Field(alias="X-Request-Id")
+
+        class Request:
+            headers: dict[str, str] = {}
+
+        with pytest.raises(AdapterValidationError) as exc_info:
+            adapter.parse_headers(cast(Any, Request()), HeaderOnly)
+
+        assert exc_info.value.errors[0]["loc"][0] == "headers"
+
+    def test_missing_body_loc_is_not_double_prefixed(
+        self, adapter: PydanticAdapter, mock_request: type
+    ) -> None:
+        req = mock_request(b"")
+        with pytest.raises(AdapterValidationError) as exc_info:
+            adapter.parse_body(req, UserModel)
+
+        assert exc_info.value.errors[0]["loc"] == ["body"]
+
+    def test_legacy_loc_disables_prefixing(self, mock_request: type) -> None:
+        legacy = PydanticAdapter(legacy_loc=True)
+        req = mock_request(b'{"name": "Al", "age": 30}')
+        with pytest.raises(AdapterValidationError) as exc_info:
+            legacy.parse_body(req, UserModel)
+
+        loc = exc_info.value.errors[0]["loc"]
+        assert loc[0] != "body"
+        assert loc == ["name"]
+
+
 # Test serialize
 class TestSerialize:
     """Tests for serialize method."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -495,6 +495,40 @@ class TestValidationErrors:
         data = json.loads(response.get_body().decode())
         assert any("name" in str(error.get("loc", [])) for error in data["detail"])
 
+    def test_body_error_loc_is_source_prefixed(
+        self, mock_request_factory: RequestFactory
+    ) -> None:
+        """End-to-end: body validation errors carry the ``body`` source prefix."""
+
+        @validate_http(body=UserModel)
+        def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
+            return ResponseModel(message="ok")
+
+        request = mock_request_factory(body=b'{"age": 30}')
+        response = handler(request)
+
+        assert response.status_code == 422
+        data = json.loads(response.get_body().decode())
+        assert data["detail"][0]["loc"][0] == "body"
+        assert data["detail"][0]["loc"] == ["body", "name"]
+
+    def test_legacy_loc_opt_out_removes_prefix(
+        self, mock_request_factory: RequestFactory
+    ) -> None:
+        """``legacy_loc=True`` restores the pre-prefix ``loc`` shape."""
+
+        @validate_http(body=UserModel, legacy_loc=True)
+        def handler(req: HttpRequest, body: UserModel) -> ResponseModel:
+            return ResponseModel(message="ok")
+
+        request = mock_request_factory(body=b'{"age": 30}')
+        response = handler(request)
+
+        assert response.status_code == 422
+        data = json.loads(response.get_body().decode())
+        assert data["detail"][0]["loc"] == ["name"]
+        assert any("name" in str(error.get("loc", [])) for error in data["detail"])
+
 
 # ---------------------------------------------------------------------------
 # Error hierarchy for non-body sources (query, path, headers)


### PR DESCRIPTION
## Summary
- **Breaking change**: validation error `loc` now carries an input-source prefix (e.g. `["body", "name"]`, `["query", ...]`, `["path", ...]`, `["headers", ...]`, `["response", ...]`) so consumers can tell which input a field error came from.
- Missing-body errors remain `["body"]` (not double-prefixed).
- Adds `legacy_loc=True` escape hatch on `validate_http(...)` / `PydanticAdapter(legacy_loc=...)` to restore the old un-prefixed `loc`.
- Corrects the PRD error example to Pydantic v2 syntax (`value_error` instead of `value_error.email`).
- Updates README, `docs/api.md` (legacy_loc tip), and `docs/changelog.md` (migration guide).

## Migration
Consumers that pattern-match on `loc` must account for the new leading source segment, or opt out with `legacy_loc=True`. See `docs/changelog.md`.

## Testing
- `make lint` ✅  `make typecheck` ✅  `make build` ✅
- `hatch run pytest --cov` ✅ coverage 97.34%
- Only failure is the pre-existing, unrelated `test_all_readme_variants_have_identical_quickstart` (README.ko drift, tracked separately).

## Notes
- Closes #257
- Depends on #256 (PR #265) — recommend merging #256 first.
- Minor version bump to be cut at release time via `make release-minor` (not in this PR).