### PR TITLE
feat(testing): ship MockHttpRequest test helper

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -205,6 +205,28 @@ def custom_error(req: func.HttpRequest, body: InputModel) -> dict[str, int]:
 !!! tip "Formatter signature"
     Keep the formatter signature exactly `(exc: Exception, status_code: int) -> dict[str, Any]`.
 
+
+## `azure_functions_validation.testing.MockHttpRequest`
+
+A public test helper for unit-testing validated handlers. It subclasses the real
+`azure.functions.HttpRequest`, so it drives the genuine `@validate_http` pipeline
+end-to-end without a running Functions host.
+
+```python
+from azure_functions_validation.testing import MockHttpRequest
+
+request = MockHttpRequest(
+    method="POST",
+    json={"name": "Alice", "email": "alice@example.com"},
+    params={"debug": "true"},
+)
+response = create_user(request)
+assert response.status_code == 200
+```
+
+See [Testing](testing.md#testing-your-handlers-with-mockhttprequest) for the full
+list of constructor options.
+
 ## Error response shape reference
 
 Default validation and parsing errors use this envelope:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,6 +2,64 @@
 
 This guide describes the test suite for `azure-functions-validation`, including how to run tests, the structure of the test suite, and guidelines for contributing new tests.
 
+## Testing your handlers with `MockHttpRequest`
+
+The package ships a public test helper, `MockHttpRequest`, so you can unit-test
+validated handlers without deploying or running the Functions host. It is a real
+`azure.functions.HttpRequest` subclass, so it drives the genuine `@validate_http`
+pipeline end-to-end.
+
+```python
+from azure_functions_validation import validate_http
+from azure_functions_validation.testing import MockHttpRequest
+from pydantic import BaseModel
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+    email: str
+
+
+class CreateUserResponse(BaseModel):
+    message: str
+
+
+@validate_http(body=CreateUserRequest, response_model=CreateUserResponse)
+def create_user(req, body: CreateUserRequest) -> CreateUserResponse:
+    return CreateUserResponse(message=f"Hello {body.name}")
+
+
+def test_create_user_ok():
+    request = MockHttpRequest(
+        method="POST",
+        json={"name": "Alice", "email": "alice@example.com"},
+    )
+    response = create_user(request)
+    assert response.status_code == 200
+    assert b"Hello Alice" in response.get_body()
+
+
+def test_create_user_missing_field_returns_422():
+    request = MockHttpRequest(method="POST", json={"name": "Alice"})
+    response = create_user(request)
+    assert response.status_code == 422
+```
+
+### Constructor options
+
+| Argument | Purpose |
+| :--- | :--- |
+| `method` | HTTP method (default `"GET"`). |
+| `url` | Request URL (default a local test URL). |
+| `json` | JSON-serializable value encoded as the body; sets `Content-Type: application/json` unless already provided. Mutually exclusive with `body`. |
+| `body` | Raw `bytes` or `str` body (a `str` is UTF-8 encoded). Mutually exclusive with `json`. |
+| `params` | Query-string parameters. |
+| `route_params` | Route (path) parameters. |
+| `headers` | Request headers. |
+
+Passing both `body` and `json` raises `ValueError`.
+
+
 ## Overview
 
 The `azure-functions-validation` project maintains a high standard of quality through a comprehensive test suite. The suite ensures that request validation, response serialization, and decorator behavior work correctly across different Python versions and Azure Functions scenarios.

--- a/src/azure_functions_validation/testing.py
+++ b/src/azure_functions_validation/testing.py
@@ -1,0 +1,101 @@
+"""Testing helpers for validated Azure Functions handlers.
+
+This module ships :class:`MockHttpRequest`, an ergonomic subclass of
+``azure.functions.HttpRequest`` that removes the boilerplate of hand-building
+request objects in unit tests.  Because it subclasses the real request type, it
+drives the genuine ``@validate_http`` pipeline end-to-end — ``get_json`` and
+``get_body`` behave exactly as they do at runtime.
+
+Example
+-------
+.. code-block:: python
+
+    from azure_functions_validation import validate_http
+    from azure_functions_validation.testing import MockHttpRequest
+
+
+    @validate_http(body=CreateUserRequest, response_model=CreateUserResponse)
+    def create_user(req, body):
+        return CreateUserResponse(message=f"Hello {body.name}")
+
+
+    def test_create_user():
+        request = MockHttpRequest(
+            method="POST",
+            json={"name": "Alice", "email": "alice@example.com"},
+        )
+        response = create_user(request)
+        assert response.status_code == 200
+"""
+
+from __future__ import annotations
+
+import json as _json
+from typing import Any, Mapping
+
+from azure.functions import HttpRequest
+
+__all__ = ["MockHttpRequest"]
+
+_JSON_CONTENT_TYPE = "application/json"
+
+
+class _Unset:
+    """Sentinel type so ``json=None`` can be distinguished from *omitted*."""
+
+
+_UNSET: Any = _Unset()
+
+
+class MockHttpRequest(HttpRequest):
+    """A convenient ``HttpRequest`` for unit-testing validated handlers.
+
+    Args:
+        method: HTTP method. Defaults to ``"GET"``.
+        url: Request URL. Defaults to a local test URL.
+        body: Raw request body as ``bytes`` or ``str``. Mutually exclusive
+            with *json*. A ``str`` is UTF-8 encoded.
+        json: A JSON-serializable value encoded as the request body. When
+            supplied, a ``Content-Type: application/json`` header is added
+            unless one is already present. Mutually exclusive with *body*.
+        params: Query-string parameters.
+        route_params: Route (path) parameters.
+        headers: Request headers.
+
+    Raises:
+        ValueError: If both *body* and *json* are provided.
+    """
+
+    def __init__(
+        self,
+        method: str = "GET",
+        url: str = "http://localhost/api/test",
+        *,
+        body: bytes | str | None = None,
+        json: Any = _UNSET,
+        params: Mapping[str, str] | None = None,
+        route_params: Mapping[str, str] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if json is not _UNSET and body is not None:
+            raise ValueError("Provide either 'body' or 'json', not both.")
+
+        resolved_headers = dict(headers or {})
+        if json is not _UNSET:
+            encoded = _json.dumps(json).encode("utf-8")
+            resolved_headers.setdefault("Content-Type", _JSON_CONTENT_TYPE)
+        elif isinstance(body, str):
+            encoded = body.encode("utf-8")
+        elif body is None:
+            encoded = b""
+        else:
+            encoded = body
+
+        super().__init__(
+            method,
+            url,
+            headers=resolved_headers,
+            params=dict(params or {}),
+            route_params=dict(route_params or {}),
+            body=encoded,
+        )

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,117 @@
+"""Tests for the ``azure_functions_validation.testing`` helpers."""
+
+from __future__ import annotations
+
+import azure.functions as func
+from azure.functions import HttpRequest
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_validation import validate_http
+from azure_functions_validation.testing import MockHttpRequest
+
+
+class _CreateUser(BaseModel):
+    name: str
+    email: str
+
+
+class _CreateUserResponse(BaseModel):
+    message: str
+    status: str = "success"
+
+
+class _Filters(BaseModel):
+    limit: int
+
+
+class TestMockHttpRequestConstruction:
+    def test_is_a_real_http_request(self) -> None:
+        request = MockHttpRequest()
+        assert isinstance(request, HttpRequest)
+
+    def test_defaults(self) -> None:
+        request = MockHttpRequest()
+        assert request.method == "GET"
+        assert request.url == "http://localhost/api/test"
+        assert request.get_body() == b""
+
+    def test_json_body_is_encoded_and_content_type_set(self) -> None:
+        request = MockHttpRequest(method="POST", json={"name": "Alice"})
+        assert request.get_json() == {"name": "Alice"}
+        assert request.headers.get("Content-Type") == "application/json"
+
+    def test_json_none_encodes_null(self) -> None:
+        request = MockHttpRequest(json=None)
+        assert request.get_body() == b"null"
+
+    def test_explicit_content_type_is_preserved(self) -> None:
+        request = MockHttpRequest(
+            json={"a": 1}, headers={"Content-Type": "application/vnd.custom+json"}
+        )
+        assert request.headers["Content-Type"] == "application/vnd.custom+json"
+
+    def test_str_body_is_utf8_encoded(self) -> None:
+        request = MockHttpRequest(body="héllo")
+        assert request.get_body() == "héllo".encode("utf-8")
+
+    def test_bytes_body_passthrough(self) -> None:
+        request = MockHttpRequest(body=b"\x00\x01")
+        assert request.get_body() == b"\x00\x01"
+
+    def test_params_and_route_params_and_headers(self) -> None:
+        request = MockHttpRequest(
+            params={"limit": "10"},
+            route_params={"id": "42"},
+            headers={"X-Trace": "abc"},
+        )
+        assert request.params["limit"] == "10"
+        assert request.route_params["id"] == "42"
+        assert request.headers["X-Trace"] == "abc"
+
+    def test_body_and_json_are_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError, match="either 'body' or 'json'"):
+            MockHttpRequest(body=b"{}", json={})
+
+
+class TestMockHttpRequestDrivesPipeline:
+    def test_valid_request_returns_200(self) -> None:
+        @validate_http(body=_CreateUser, response_model=_CreateUserResponse)
+        def create_user(req: func.HttpRequest, body: _CreateUser) -> _CreateUserResponse:
+            return _CreateUserResponse(message=f"Hello {body.name}")
+
+        request = MockHttpRequest(
+            method="POST", json={"name": "Alice", "email": "alice@example.com"}
+        )
+        response = create_user(request)
+        assert response.status_code == 200
+        assert b"Hello Alice" in response.get_body()
+
+    def test_invalid_request_returns_422(self) -> None:
+        @validate_http(body=_CreateUser)
+        def create_user(req: func.HttpRequest, body: _CreateUser) -> dict[str, bool]:
+            return {"ok": True}
+
+        request = MockHttpRequest(method="POST", json={"name": "Alice"})
+        response = create_user(request)
+        assert response.status_code == 422
+
+    def test_query_params_validated(self) -> None:
+        @validate_http(query=_Filters)
+        def search(req: func.HttpRequest, query: _Filters) -> dict[str, int]:
+            return {"limit": query.limit}
+
+        response = search(MockHttpRequest(params={"limit": "5"}))
+        assert response.status_code == 200
+        assert b'"limit": 5' in response.get_body()
+
+    @pytest.mark.anyio
+    async def test_async_handler(self) -> None:
+        @validate_http(body=_CreateUser, response_model=_CreateUserResponse)
+        async def create_user(req: func.HttpRequest, body: _CreateUser) -> _CreateUserResponse:
+            return _CreateUserResponse(message=f"Hello {body.name}")
+
+        request = MockHttpRequest(method="POST", json={"name": "Bob", "email": "bob@example.com"})
+        response = await create_user(request)
+        assert response.status_code == 200
+        assert b"Hello Bob" in response.get_body()


### PR DESCRIPTION
## Summary
- Adds `azure_functions_validation.testing.MockHttpRequest` — a real `azure.functions.HttpRequest` subclass with an ergonomic constructor so users can unit-test `@validate_http` handlers **without** deploying or running the Functions host.
- Because it subclasses the genuine request type, `get_json`/`get_body` behave exactly as at runtime and it drives the real validation pipeline end-to-end.
- Constructor conveniences: `json=` auto-encodes + sets `Content-Type: application/json`, `body=` accepts `str`/`bytes`, plus `params` / `route_params` / `headers`. Passing both `body` and `json` raises `ValueError`.

## API placement
Shipped in the `azure_functions_validation.testing` submodule (idiomatic, mirrors `fastapi.testclient`). The top-level `__all__` surface is intentionally unchanged, so the public-API stability test is unaffected.

## Docs
- `docs/testing.md`: new "Testing your handlers with `MockHttpRequest`" section with a runnable example + constructor-option table.
- `docs/api.md`: reference entry linking to the testing guide.
- README untouched (docs-only addition), so no translation-sync required.

## Testing
- `make lint` ✅  `make typecheck` ✅  `make build` ✅
- `hatch run pytest --cov` ✅ coverage 97.86% (new `testing.py` fully covered)
- New `tests/test_testing.py`: construction variants + valid/invalid/query/async handlers driven purely via the helper.
- Only failure is the pre-existing, unrelated `test_all_readme_variants_have_identical_quickstart` (README.ko drift, tracked separately).

## Notes
- Closes #258
- Branches off fresh `main`; independent of the other open PRs.