### PR TITLE
feat(metadata): define endpoint namespace SPEC and JSON Schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,18 +60,8 @@ security: ensure-hatch
 	@$(HATCH) run security
 
 .PHONY: check-schema-hash
-check-schema-hash:
-	@cd src/azure_functions_validation/schemas && \
-	  EXPECTED=$$(cut -d' ' -f1 endpoint.schema.sha256) && \
-	  ACTUAL=$$(python3 -c "import hashlib; print(hashlib.sha256(open('endpoint.schema.json','rb').read()).hexdigest())") && \
-	  if [ "$$EXPECTED" != "$$ACTUAL" ]; then \
-	    echo "endpoint.schema.json digest drift:"; \
-	    echo "  pinned:  $$EXPECTED"; \
-	    echo "  actual:  $$ACTUAL"; \
-	    echo "Update endpoint.schema.sha256 (and sync sibling packages) if intentional."; \
-	    exit 1; \
-	  fi
-	@echo "endpoint.schema.json digest matches pin."
+check-schema-hash: ensure-hatch
+	@$(HATCH) run python -c "import hashlib, pathlib, sys; d = pathlib.Path('src/azure_functions_validation/schemas'); expected = (d / 'endpoint.schema.sha256').read_text().split()[0]; actual = hashlib.sha256((d / 'endpoint.schema.json').read_bytes()).hexdigest(); print('endpoint.schema.json digest matches pin.') if expected == actual else sys.exit('endpoint.schema.json digest drift:\n  pinned:  ' + expected + '\n  actual:  ' + actual + '\nUpdate endpoint.schema.sha256 (and sync sibling packages) if intentional.')"
 
 .PHONY: check
 check: ensure-hatch

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,20 @@ lint: ensure-hatch
 security: ensure-hatch
 	@$(HATCH) run security
 
+.PHONY: check-schema-hash
+check-schema-hash:
+	@cd src/azure_functions_validation/schemas && \
+	  EXPECTED=$$(cut -d' ' -f1 endpoint.schema.sha256) && \
+	  ACTUAL=$$(python3 -c "import hashlib; print(hashlib.sha256(open('endpoint.schema.json','rb').read()).hexdigest())") && \
+	  if [ "$$EXPECTED" != "$$ACTUAL" ]; then \
+	    echo "endpoint.schema.json digest drift:"; \
+	    echo "  pinned:  $$EXPECTED"; \
+	    echo "  actual:  $$ACTUAL"; \
+	    echo "Update endpoint.schema.sha256 (and sync sibling packages) if intentional."; \
+	    exit 1; \
+	  fi
+	@echo "endpoint.schema.json digest matches pin."
+
 .PHONY: check
 check: ensure-hatch
 	@$(MAKE) lint
@@ -67,6 +81,7 @@ check: ensure-hatch
 
 .PHONY: check-all
 check-all: ensure-hatch
+	@$(MAKE) check-schema-hash
 	@$(MAKE) check
 	@$(MAKE) test
 	@$(MAKE) security

--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -1,0 +1,113 @@
+# `endpoint` metadata namespace — SPEC
+
+Status: **v1** · Owner namespace: `endpoint` · Issue: [#271](https://github.com/yeongseon/azure-functions-validation-python/issues/271) · Umbrella: [#270](https://github.com/yeongseon/azure-functions-validation-python/issues/270)
+
+## Purpose
+
+The Azure Functions Python DX Toolkit lets sibling packages cooperate without
+importing one another. Decorators attach a single dict to the wrapped handler
+under the conventional attribute `_azure_functions_metadata`, keyed by a
+package-owned **namespace** string. Consumers discover metadata by reading that
+attribute — never by importing the producer.
+
+The `endpoint` namespace is the **shared, OpenAPI-ready contract**. Producer
+packages (`azure-functions-validation`, `azure-functions-langgraph`, …) write
+it; the consumer (`azure-functions-openapi`) reads it and derives the OpenAPI
+spec directly, instead of reconstructing OpenAPI shapes per producer.
+
+The JSON Schema in
+[`src/azure_functions_validation/schemas/endpoint.schema.json`](../src/azure_functions_validation/schemas/endpoint.schema.json)
+is the **single source of truth** for the payload shape. Every producer
+validates its emitted payload against this schema in tests so the dict cannot
+drift.
+
+## Distribution & sync
+
+- The schema is a **public** subpackage
+  (`azure_functions_validation.schemas`), shipped as package data and loaded
+  via `importlib.resources`. No new runtime dependency is introduced;
+  `jsonschema` is required only to *validate* payloads and is test-only.
+- The contract is **replicated** across packages, not shared through a runtime
+  dependency (same philosophy as the vendored `_metadata_helpers.py`).
+- Drift is caught mechanically: `endpoint.schema.sha256` pins the file digest
+  and `make check-schema-hash` (wired into `make check-all`) fails on any
+  change. When you intentionally change the schema, update the pin and
+  hand-sync sibling packages in the same release train.
+
+## Payload shape (version 1)
+
+```jsonc
+{
+  "version": 1,                     // const 1; consumers WARN (not fail) on unknown
+  "request_body": { /* JSON Schema */ } | null,
+  "request_body_required": true,    // default true unless every body field has a default
+  "parameters": [                   // OpenAPI parameter objects (query/path/header)
+    { "name": "id", "in": "path", "required": true, "schema": { /* JSON Schema */ } }
+  ],
+  "responses": {                    // status-code (string) -> response object; or null
+    "200": { "description": "OK", "schema": { /* JSON Schema */ } }
+  } | null,
+  "summary": "…",                   // optional
+  "description": "…",               // optional
+  "tags": ["users"],                // optional
+  "security": [ { /* requirement */ } ] // optional
+}
+```
+
+### `path` and `method` are intentionally OMITTED
+
+The Azure Functions route binding (`@app.route(route=…, methods=…)`) is the
+single source of truth for path and HTTP methods. The consumer derives them at
+scan time from the binding, so producers must not duplicate them here.
+
+## Canonicalization rules (producers MUST follow)
+
+Producers generate embedded schemas from Pydantic models with **exactly** these
+settings so output is stable and consumer-mergeable:
+
+| Rule | Value |
+| --- | --- |
+| Alias handling | `by_alias=True` |
+| Request schema mode | `mode='validation'` |
+| Response schema mode | `mode='serialization'` |
+| Ref template | Pydantic default `#/$defs/{model}` |
+| `$defs` | **left UNRESOLVED** — the consumer hoists them to `components/schemas` |
+| Generator class | Pydantic default `GenerateJsonSchema` (pin explicitly if customized; Pydantic minor bumps can change output) |
+| `request_body_required` | `True` unless every field of the body model has a default |
+
+### Structural rule: `$defs` if `$ref`
+
+Any embedded schema that contains a `$ref` **anywhere** MUST carry a top-level
+`$defs` mapping. This guards against a producer pre-resolving (or dropping)
+definitions, which would break the consumer's hoisting and make it no longer
+the sole `$ref`-collision authority. This rule is not expressible in JSON Schema
+alone and is enforced by
+`azure_functions_validation.schemas.assert_defs_present_if_ref_used`.
+
+## Consumer discipline
+
+- Consumers MUST read the payload via an explicit allowlist / typed reader —
+  never `**payload`-splat into a call. New optional keys must be additively
+  ignorable.
+- Consumers MUST treat an unknown `version` as a warning and fall back to their
+  prior discovery path, not raise.
+- Consumers remain the sole authority for `$ref` collision resolution; embedded
+  `$defs` are inputs, not final `components/schemas`.
+
+## Versioning policy
+
+- `version` starts at `1`. Bump only on a **breaking** payload change.
+- Additive, optional fields do **not** bump the version.
+- On a bump, update the schema, its SHA-256 pin, this spec, and every sibling
+  producer/consumer in the same release train.
+
+## API
+
+```python
+from azure_functions_validation.schemas import (
+    ENDPOINT_METADATA_VERSION,      # 1
+    load_endpoint_schema,           # -> dict (fresh copy)
+    endpoint_schema_sha256,         # -> hex digest of shipped bytes
+    assert_defs_present_if_ref_used # structural guard, raises ValueError
+)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pytest-anyio",
     "pytest-cov",
     "ruff==0.16.0",
+    "jsonschema",
     "requests",
     "types-requests",
 ]
@@ -63,6 +64,10 @@ build-backend = "hatchling.build"
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/azure_functions_validation/schemas/endpoint.schema.json" = "azure_functions_validation/schemas/endpoint.schema.json"
+"src/azure_functions_validation/schemas/endpoint.schema.sha256" = "azure_functions_validation/schemas/endpoint.schema.sha256"
 
 [tool.hatch.version]
 path = "src/azure_functions_validation/__init__.py"

--- a/src/azure_functions_validation/schemas/__init__.py
+++ b/src/azure_functions_validation/schemas/__init__.py
@@ -1,0 +1,108 @@
+"""Public schema package for the Azure Functions Python DX Toolkit.
+
+This subpackage ships the JSON Schema for the cross-package ``endpoint``
+metadata namespace and a small, dependency-free loader. Producer packages
+(this one, ``azure-functions-langgraph``, ...) write the ``endpoint`` payload;
+consumer packages (``azure-functions-openapi``) read it. The schema is the
+single source of truth for the payload shape so the dict cannot silently
+drift across packages.
+
+The schema JSON is distributed as package data and loaded via
+:mod:`importlib.resources`, so it is importable at runtime without any new
+runtime dependency. ``jsonschema`` is only required to *validate* payloads
+against the schema and is a test-only dependency.
+
+See ``docs/METADATA_SPEC.md`` for the full contract, version policy, and
+canonicalization rules.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from importlib import resources
+import json
+from typing import Any
+
+__all__ = [
+    "ENDPOINT_METADATA_VERSION",
+    "ENDPOINT_SCHEMA_FILENAME",
+    "assert_defs_present_if_ref_used",
+    "endpoint_schema_sha256",
+    "load_endpoint_schema",
+    "pinned_endpoint_schema_sha256",
+]
+
+#: Current version of the ``endpoint`` namespace payload. Bump only on a
+#: breaking payload change; consumers warn (not fail) on unknown versions.
+ENDPOINT_METADATA_VERSION = 1
+
+#: Name of the shipped JSON Schema file within this package.
+ENDPOINT_SCHEMA_FILENAME = "endpoint.schema.json"
+
+#: Name of the shipped SHA-256 pin file within this package.
+_ENDPOINT_SCHEMA_SHA256_FILENAME = "endpoint.schema.sha256"
+
+
+def _read_schema_bytes() -> bytes:
+    """Return the raw bytes of the shipped schema file."""
+    return resources.files(__name__).joinpath(ENDPOINT_SCHEMA_FILENAME).read_bytes()
+
+
+def load_endpoint_schema() -> dict[str, Any]:
+    """Load and parse the ``endpoint`` namespace JSON Schema.
+
+    Returns a fresh ``dict`` on each call so callers may mutate it freely.
+    """
+    data: dict[str, Any] = json.loads(_read_schema_bytes().decode("utf-8"))
+    return data
+
+
+def endpoint_schema_sha256() -> str:
+    """Return the SHA-256 hex digest of the shipped schema file bytes."""
+    return hashlib.sha256(_read_schema_bytes()).hexdigest()
+
+
+def pinned_endpoint_schema_sha256() -> str:
+    """Return the pinned SHA-256 digest recorded alongside the schema."""
+    text = (
+        resources.files(__name__)
+        .joinpath(_ENDPOINT_SCHEMA_SHA256_FILENAME)
+        .read_text(encoding="utf-8")
+    )
+    # The pin file may carry a trailing filename (``<digest>  <name>``); take
+    # the first whitespace-delimited token.
+    return text.strip().split()[0]
+
+
+def assert_defs_present_if_ref_used(schema: dict[str, Any]) -> None:
+    """Enforce the structural rule: any ``$ref`` requires a sibling ``$defs``.
+
+    Producers MUST embed Pydantic schemas with ``$defs`` left unresolved so the
+    consumer (openapi) stays the sole ``$ref``-collision authority. A schema
+    that contains a ``$ref`` anywhere but omits a top-level ``$defs`` block
+    indicates a producer pre-resolved (or dropped) definitions, which breaks
+    consumer hoisting. This is not expressible in JSON Schema alone, so it is
+    checked here.
+
+    Raises:
+        ValueError: if a ``$ref`` occurs anywhere in ``schema`` without a
+            top-level ``$defs`` mapping.
+    """
+    if not isinstance(schema, dict):
+        return
+    if _contains_ref(schema) and not isinstance(schema.get("$defs"), dict):
+        raise ValueError(
+            "embedded schema uses '$ref' but has no top-level '$defs'; "
+            "producers must keep Pydantic '$defs' unresolved"
+        )
+
+
+def _contains_ref(node: Any) -> bool:
+    """Return True if ``$ref`` appears anywhere within ``node``."""
+    if isinstance(node, dict):
+        if "$ref" in node:
+            return True
+        return any(_contains_ref(value) for value in node.values())
+    if isinstance(node, list):
+        return any(_contains_ref(item) for item in node)
+    return False

--- a/src/azure_functions_validation/schemas/__init__.py
+++ b/src/azure_functions_validation/schemas/__init__.py
@@ -74,7 +74,7 @@ def pinned_endpoint_schema_sha256() -> str:
     return text.strip().split()[0]
 
 
-def assert_defs_present_if_ref_used(schema: dict[str, Any]) -> None:
+def assert_defs_present_if_ref_used(schema: object) -> None:
     """Enforce the structural rule: any ``$ref`` requires a sibling ``$defs``.
 
     Producers MUST embed Pydantic schemas with ``$defs`` left unresolved so the
@@ -85,8 +85,10 @@ def assert_defs_present_if_ref_used(schema: dict[str, Any]) -> None:
     checked here.
 
     Raises:
-        ValueError: if a ``$ref`` occurs anywhere in ``schema`` without a
-            top-level ``$defs`` mapping.
+        ValueError: if ``schema`` is a mapping that contains a ``$ref``
+            anywhere without a top-level ``$defs`` mapping. Non-mapping
+            inputs are ignored (the rule only applies to schema objects).
+
     """
     if not isinstance(schema, dict):
         return

--- a/src/azure_functions_validation/schemas/endpoint.schema.json
+++ b/src/azure_functions_validation/schemas/endpoint.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yeongseon.github.io/azure-functions-python-dx/endpoint.schema.json",
+  "title": "Azure Functions DX Toolkit — endpoint metadata namespace (v1)",
+  "description": "Shape of _azure_functions_metadata[\"endpoint\"]. Producer packages (e.g. azure-functions-validation, azure-functions-langgraph) write this payload; consumer packages (e.g. azure-functions-openapi) read it. This contract is replicated across toolkit packages, not shared via a runtime dependency. Keep byte-identical copies in sync via the pinned SHA-256 digest.",
+  "type": "object",
+  "required": ["version"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "description": "Schema version for the endpoint namespace payload. Consumers MUST warn (not fail) on an unknown version and fall back gracefully.",
+      "const": 1
+    },
+    "request_body": {
+      "description": "JSON Schema of the request body model, or null when the endpoint takes no body. Canonicalization: Pydantic model_json_schema(by_alias=True, mode='validation', ref_template='#/$defs/{model}'). $defs are left UNRESOLVED — the consumer (openapi) hoists them into components/schemas and remains the sole $ref-collision authority.",
+      "anyOf": [
+        { "$ref": "#/$defs/jsonSchema" },
+        { "type": "null" }
+      ]
+    },
+    "request_body_required": {
+      "description": "Whether the request body is required. Defaults to true unless every field of the body model has a default.",
+      "type": "boolean"
+    },
+    "parameters": {
+      "description": "OpenAPI-style parameter objects derived from query/path/header models. Refs, if present, MUST remain unresolved and be accompanied by $defs on the owning schema.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/parameter" }
+    },
+    "responses": {
+      "description": "Map of HTTP status code (as string) to a response object carrying the response model's JSON Schema. null when no response model is declared. Response schemas use mode='serialization'.",
+      "anyOf": [
+        {
+          "type": "object",
+          "propertyNames": { "pattern": "^[1-5][0-9]{2}$" },
+          "additionalProperties": { "$ref": "#/$defs/response" }
+        },
+        { "type": "null" }
+      ]
+    },
+    "summary": {
+      "description": "Short human-readable summary of the operation.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Longer human-readable description of the operation.",
+      "type": "string"
+    },
+    "tags": {
+      "description": "OpenAPI operation tags.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "security": {
+      "description": "OpenAPI security requirement objects for the operation.",
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  },
+  "$defs": {
+    "jsonSchema": {
+      "description": "An embedded JSON Schema document (Pydantic-generated). Kept permissive: producers embed schemas verbatim; the consumer validates structure.",
+      "type": "object"
+    },
+    "parameter": {
+      "description": "OpenAPI parameter object subset.",
+      "type": "object",
+      "required": ["name", "in"],
+      "properties": {
+        "name": { "type": "string" },
+        "in": {
+          "type": "string",
+          "enum": ["query", "path", "header", "cookie"]
+        },
+        "required": { "type": "boolean" },
+        "description": { "type": "string" },
+        "schema": { "$ref": "#/$defs/jsonSchema" }
+      },
+      "additionalProperties": false
+    },
+    "response": {
+      "description": "OpenAPI-style response object carrying an embedded response schema.",
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" },
+        "schema": {
+          "anyOf": [
+            { "$ref": "#/$defs/jsonSchema" },
+            { "type": "null" }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/azure_functions_validation/schemas/endpoint.schema.sha256
+++ b/src/azure_functions_validation/schemas/endpoint.schema.sha256
@@ -1,0 +1,1 @@
+05a5f945adf9c8e2730cdb0af92acbdf53299db111c3037e34f65ba19b6f0db4  endpoint.schema.json

--- a/tests/test_endpoint_schema.py
+++ b/tests/test_endpoint_schema.py
@@ -1,0 +1,181 @@
+"""Tests for the ``endpoint`` metadata namespace schema (issue #271).
+
+These tests pin the shape of ``_azure_functions_metadata["endpoint"]`` so the
+cross-package contract cannot drift. They validate that the shipped JSON Schema
+is itself a valid JSON Schema, that a representative payload passes, that an
+invalid payload fails, and that the ``$defs``-if-``$ref`` structural rule and the
+SHA-256 pin hold.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from importlib import resources
+from typing import Any
+
+import jsonschema
+from jsonschema.validators import Draft202012Validator
+import pytest
+
+from azure_functions_validation.schemas import (
+    ENDPOINT_METADATA_VERSION,
+    ENDPOINT_SCHEMA_FILENAME,
+    assert_defs_present_if_ref_used,
+    endpoint_schema_sha256,
+    load_endpoint_schema,
+    pinned_endpoint_schema_sha256,
+)
+
+
+def _representative_payload() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "request_body": {
+            "type": "object",
+            "title": "CreateUserRequest",
+            "properties": {
+                "name": {"type": "string"},
+                "email": {"type": "string"},
+            },
+            "required": ["name", "email"],
+        },
+        "request_body_required": True,
+        "parameters": [
+            {
+                "name": "user_id",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "integer"},
+            }
+        ],
+        "responses": {
+            "200": {
+                "description": "OK",
+                "schema": {
+                    "type": "object",
+                    "title": "UserResponse",
+                    "properties": {"id": {"type": "integer"}, "name": {"type": "string"}},
+                },
+            }
+        },
+        "summary": "Create a user",
+        "description": "Creates a user and returns it.",
+        "tags": ["users"],
+        "security": [{"apiKey": []}],
+    }
+
+
+class TestSchemaDocument:
+    def test_schema_is_valid_json_schema(self) -> None:
+        schema = load_endpoint_schema()
+        # Raises jsonschema.exceptions.SchemaError if the document is invalid.
+        Draft202012Validator.check_schema(schema)
+
+    def test_schema_declares_2020_12(self) -> None:
+        schema = load_endpoint_schema()
+        assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    def test_load_returns_fresh_copy(self) -> None:
+        first = load_endpoint_schema()
+        first["mutated"] = True
+        second = load_endpoint_schema()
+        assert "mutated" not in second
+
+    def test_version_constant_matches_schema(self) -> None:
+        schema = load_endpoint_schema()
+        assert ENDPOINT_METADATA_VERSION == schema["properties"]["version"]["const"]
+        assert ENDPOINT_METADATA_VERSION == 1
+
+
+class TestPayloadValidation:
+    def test_representative_payload_passes(self) -> None:
+        jsonschema.validate(_representative_payload(), load_endpoint_schema())
+
+    def test_minimal_payload_passes(self) -> None:
+        jsonschema.validate({"version": 1}, load_endpoint_schema())
+
+    def test_null_request_body_and_responses_pass(self) -> None:
+        payload = {"version": 1, "request_body": None, "responses": None}
+        jsonschema.validate(payload, load_endpoint_schema())
+
+    def test_missing_version_fails(self) -> None:
+        payload = _representative_payload()
+        del payload["version"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(payload, load_endpoint_schema())
+
+    def test_wrong_version_fails(self) -> None:
+        payload = _representative_payload()
+        payload["version"] = 2
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(payload, load_endpoint_schema())
+
+    def test_unknown_top_level_key_fails(self) -> None:
+        payload = _representative_payload()
+        payload["path"] = "/users"  # path is intentionally not part of the contract
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(payload, load_endpoint_schema())
+
+    def test_bad_parameter_location_fails(self) -> None:
+        payload = _representative_payload()
+        payload["parameters"][0]["in"] = "body"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(payload, load_endpoint_schema())
+
+    def test_non_status_response_key_fails(self) -> None:
+        payload = _representative_payload()
+        payload["responses"] = {"ok": {"description": "OK"}}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(payload, load_endpoint_schema())
+
+
+class TestDefsIfRefRule:
+    def test_ref_with_defs_passes(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"pet": {"$ref": "#/$defs/Pet"}},
+            "$defs": {"Pet": {"type": "object"}},
+        }
+        assert_defs_present_if_ref_used(schema)  # no raise
+
+    def test_ref_without_defs_raises(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"pet": {"$ref": "#/$defs/Pet"}},
+        }
+        with pytest.raises(ValueError, match=r"\$defs"):
+            assert_defs_present_if_ref_used(schema)
+
+    def test_nested_ref_without_defs_raises(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "items": {"type": "array", "items": {"$ref": "#/$defs/Item"}},
+            },
+        }
+        with pytest.raises(ValueError, match=r"\$defs"):
+            assert_defs_present_if_ref_used(schema)
+
+    def test_no_ref_no_defs_passes(self) -> None:
+        assert_defs_present_if_ref_used({"type": "object"})
+
+    def test_ref_inside_list_without_defs_raises(self) -> None:
+        schema = {"type": "object", "anyOf": [{"$ref": "#/$defs/A"}]}
+        with pytest.raises(ValueError, match=r"\$defs"):
+            assert_defs_present_if_ref_used(schema)
+
+    def test_non_dict_is_ignored(self) -> None:
+        assert_defs_present_if_ref_used("not a dict")  # type: ignore[arg-type]
+
+
+class TestSchemaHashPin:
+    def test_runtime_digest_matches_pin(self) -> None:
+        assert endpoint_schema_sha256() == pinned_endpoint_schema_sha256()
+
+    def test_digest_matches_file_bytes(self) -> None:
+        raw = (
+            resources.files("azure_functions_validation.schemas")
+            .joinpath(ENDPOINT_SCHEMA_FILENAME)
+            .read_bytes()
+        )
+        assert endpoint_schema_sha256() == hashlib.sha256(raw).hexdigest()

--- a/tests/test_endpoint_schema.py
+++ b/tests/test_endpoint_schema.py
@@ -165,7 +165,7 @@ class TestDefsIfRefRule:
             assert_defs_present_if_ref_used(schema)
 
     def test_non_dict_is_ignored(self) -> None:
-        assert_defs_present_if_ref_used("not a dict")  # type: ignore[arg-type]
+        assert_defs_present_if_ref_used("not a dict")
 
 
 class TestSchemaHashPin:


### PR DESCRIPTION
## Summary

Lands the shared, versioned `endpoint` metadata namespace contract — the first item on the #270 critical path. Producer packages write `_azure_functions_metadata["endpoint"]`; the openapi consumer reads it and derives OpenAPI directly instead of reconstructing shapes per producer. This PR ships **only** the spec + schema + loader + tests; the producer write lands in #272.

- **Public `azure_functions_validation.schemas` subpackage** with `endpoint.schema.json` (JSON Schema Draft 2020-12, payload **v1**). `path`/`method` are intentionally omitted — the Azure route binding is the single source of truth.
- **Dependency-free loader**: `load_endpoint_schema()`, `endpoint_schema_sha256()`, `pinned_endpoint_schema_sha256()`, and `assert_defs_present_if_ref_used()` enforcing the **`$defs`-if-`$ref`** structural rule (keeps openapi the sole `$ref`-collision authority).
- **Drift protection**: `endpoint.schema.sha256` pin + `make check-schema-hash` wired into `make check-all` (same vendor-and-pin philosophy as `_metadata_helpers.py`).
- **Spec** `docs/METADATA_SPEC.md`: namespace, version policy, canonicalization rules (`by_alias=True`, request `mode='validation'` / response `mode='serialization'`, `ref_template='#/$defs/{model}'`, `$defs` unresolved, `request_body_required` default), and consumer allowlist discipline.
- **Packaging**: schema shipped as wheel package data; `jsonschema` added as a **dev-only** dependency (no new runtime dep).

## Canonicalization contract (v1)

Producers embed Pydantic schemas verbatim with `$defs` left unresolved; the openapi consumer hoists them into `components/schemas`. Consumers read via an explicit allowlist and treat an unknown `version` as a warning (never fail).

## Testing

- `make check-schema-hash` — digest matches pin ✅
- ruff check + format — clean ✅
- mypy strict — clean ✅
- Full suite: **270 passed, 6 skipped** (e2e); coverage **98.09%** (gate 95%) ✅
- Wheel build ships `azure_functions_validation/schemas/*.json|*.sha256` ✅

## Review

Oracle design consult (pre-impl): "Sound design. No structural blockers. Ship it." Oracle implementation review: **92/100 — PR-ready**; its low-severity notes (add `pinned_endpoint_schema_sha256` to `__all__`, tighten `additionalProperties` on `parameter`/`response` defs, spec issue reference) are applied in this PR.

Refs #271, #270