### PR TITLE
feat(decorator): write endpoint namespace in _make_wrapper

### DIFF
--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -45,7 +45,7 @@ drift.
     { "name": "id", "in": "path", "required": true, "schema": { /* JSON Schema */ } }
   ],
   "responses": {                    // status-code (string) -> response object; or null
-    "200": { "description": "OK", "schema": { /* JSON Schema */ } }
+    "200": { "schema": { /* JSON Schema */ } }  // "description" optional; producer omits it in v1
   } | null,
   "summary": "…",                   // optional
   "description": "…",               // optional

--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -2,6 +2,12 @@
 
 Status: **v1** · Owner namespace: `endpoint` · Issue: [#271](https://github.com/yeongseon/azure-functions-validation-python/issues/271) · Umbrella: [#270](https://github.com/yeongseon/azure-functions-validation-python/issues/270)
 
+> **Localization:** This specification is a canonical, English-only technical
+> document (the machine-readable source of truth is the JSON Schema it links to).
+> It is intentionally **not** part of the translated README set
+> (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) and requires no translation
+> updates when it changes.
+
 ## Purpose
 
 The Azure Functions Python DX Toolkit lets sibling packages cooperate without

--- a/src/azure_functions_validation/_endpoint.py
+++ b/src/azure_functions_validation/_endpoint.py
@@ -1,0 +1,150 @@
+"""Builder for the cross-package ``endpoint`` metadata namespace.
+
+``validate_http`` writes two namespaces onto the wrapped handler under the
+shared ``_azure_functions_metadata`` convention attribute:
+
+* ``"validation"`` — this package's own request/response model references
+  (kept for the deprecation cycle; see :mod:`._metadata`).
+* ``"endpoint"`` — the shared, OpenAPI-ready contract consumed by
+  ``azure-functions-openapi``. Unlike the ``validation`` namespace (which
+  carries Pydantic model *classes*), the ``endpoint`` payload is entirely
+  *self-contained* JSON Schema: the consumer needs no import of this package
+  and no access to the user's model classes.
+
+The payload shape and canonicalization rules are pinned by
+``schemas/endpoint.schema.json`` and documented in ``docs/METADATA_SPEC.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from pydantic import BaseModel
+
+from ._metadata import _merge_namespace
+from .schemas import ENDPOINT_METADATA_VERSION, _contains_ref
+
+#: Namespace owned by the shared endpoint contract.
+ENDPOINT_NAMESPACE = "endpoint"
+
+#: Pydantic ref template pinned by the SPEC so ``$defs`` stay unresolved and the
+#: consumer (openapi) remains the sole ``$ref``-collision authority.
+_REF_TEMPLATE = "#/$defs/{model}"
+
+
+class EndpointMetadata(TypedDict, total=False):
+    """Shape of ``_azure_functions_metadata["endpoint"]`` (schema version 1)."""
+
+    version: int
+    request_body: dict[str, Any] | None
+    request_body_required: bool
+    parameters: list[dict[str, Any]]
+    responses: dict[str, dict[str, Any]] | None
+
+
+def _is_model_type(model: Any) -> bool:
+    """Return ``True`` if *model* is a Pydantic ``BaseModel`` subclass."""
+    return isinstance(model, type) and issubclass(model, BaseModel)
+
+
+def _model_schema(model: type[BaseModel], mode: str) -> dict[str, Any]:
+    """Generate a model's JSON Schema using the SPEC-pinned canonicalization."""
+    return model.model_json_schema(
+        by_alias=True,
+        ref_template=_REF_TEMPLATE,
+        mode=mode,  # type: ignore[arg-type]
+    )
+
+
+
+def _attach_defs_if_ref(
+    field_schema: dict[str, Any],
+    defs: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Attach ``$defs`` to a per-field schema when it uses a ``$ref``.
+
+    Keeps the SPEC's ``$defs``-if-``$ref`` invariant intact for parameter
+    schemas that reference a nested model, so the consumer can hoist them.
+    """
+    if defs and _contains_ref(field_schema):
+        merged = dict(field_schema)
+        merged["$defs"] = defs
+        return merged
+    return field_schema
+
+
+def _build_parameters(model: type[BaseModel], location: str) -> list[dict[str, Any]]:
+    """Build OpenAPI parameter objects from a query/path/header model.
+
+    Parameter ``name`` uses the field's serialization alias (``by_alias=True``)
+    so it matches the wire contract. ``path`` parameters are always required.
+    """
+    schema = _model_schema(model, "validation")
+    properties: dict[str, Any] = schema.get("properties", {})
+    required_names = set(schema.get("required", []))
+    defs = schema.get("$defs")
+
+    params: list[dict[str, Any]] = []
+    for name, field_schema in properties.items():
+        params.append(
+            {
+                "name": name,
+                "in": location,
+                "required": location == "path" or name in required_names,
+                "schema": _attach_defs_if_ref(dict(field_schema), defs),
+            }
+        )
+    return params
+
+
+def build_endpoint_metadata(config: Any) -> EndpointMetadata:
+    """Build the ``endpoint`` namespace payload from a pipeline config.
+
+    ``config`` exposes ``body``, ``query``, ``path``, ``headers``,
+    ``response_model``, and ``success_status_code``.
+    """
+    body = config.body
+    if _is_model_type(body):
+        request_body: dict[str, Any] | None = _model_schema(body, "validation")
+        request_body_required = any(field.is_required() for field in body.model_fields.values())
+    else:
+        request_body = None
+        request_body_required = False
+
+    parameters: list[dict[str, Any]] = []
+    for model, location in (
+        (config.query, "query"),
+        (config.path, "path"),
+        (config.headers, "header"),
+    ):
+        if _is_model_type(model):
+            parameters.extend(_build_parameters(model, location))
+
+    response_model = config.response_model
+    if _is_model_type(response_model):
+        status = str(getattr(config, "success_status_code", 200) or 200)
+        responses: dict[str, dict[str, Any]] | None = {
+            status: {"schema": _model_schema(response_model, "serialization")}
+        }
+    else:
+        responses = None
+
+    payload: EndpointMetadata = {
+        "version": ENDPOINT_METADATA_VERSION,
+        "request_body": request_body,
+        "request_body_required": request_body_required,
+        "parameters": parameters,
+        "responses": responses,
+    }
+    return payload
+
+
+def set_endpoint_metadata(wrapper: Any, source: Any, payload: EndpointMetadata) -> None:
+    """Merge the ``endpoint`` namespace onto *wrapper* without clobbering others.
+
+    Seeds from any existing convention attribute on *source* (e.g. the
+    ``validation`` namespace already written by this decorator), merges in
+    *payload* under the ``endpoint`` namespace, and writes the result onto
+    *wrapper*.
+    """
+    _merge_namespace(wrapper, source, ENDPOINT_NAMESPACE, payload)

--- a/src/azure_functions_validation/_metadata.py
+++ b/src/azure_functions_validation/_metadata.py
@@ -51,6 +51,20 @@ class ValidationMetadata(_BaseMetadata):
     response_model: Any
 
 
+def _merge_namespace(wrapper: Any, source: Any, namespace: str, payload: Any) -> None:
+    """Merge *payload* under *namespace* onto *wrapper* without clobbering others.
+
+    Seeds from any pre-existing convention attribute on *source* (set by other
+    decorators applied before this one, or by an earlier namespace write in the
+    same decorator), merges in *payload* under *namespace*, and writes the
+    result onto *wrapper*.
+    """
+    existing = getattr(source, METADATA_ATTR, None)
+    base: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    base[namespace] = payload
+    setattr(wrapper, METADATA_ATTR, base)
+
+
 def set_validation_metadata(
     wrapper: Any,
     func: Any,
@@ -62,10 +76,7 @@ def set_validation_metadata(
     decorators applied before this one), merges in ``payload`` under the
     ``validation`` namespace, and writes the result onto ``wrapper``.
     """
-    existing = getattr(func, METADATA_ATTR, None)
-    base: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
-    base[NAMESPACE] = payload
-    setattr(wrapper, METADATA_ATTR, base)
+    _merge_namespace(wrapper, func, NAMESPACE, payload)
 
 
 def read_validation_metadata(func: Any) -> ValidationMetadata | None:

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -8,6 +8,7 @@ import warnings
 
 from pydantic import TypeAdapter
 
+from ._endpoint import build_endpoint_metadata, set_endpoint_metadata
 from ._metadata import ValidationMetadata, set_validation_metadata
 from ._metadata_helpers import SAFE_IDENTITY_ATTRS, copy_identity_attrs
 from .adapter import PydanticAdapter, ValidationAdapter
@@ -313,5 +314,10 @@ def _make_wrapper(
         "response_model": config.response_model,
     }
     set_validation_metadata(wrapper, func, _payload)
+
+    # Also expose the shared, OpenAPI-ready "endpoint" namespace (self-contained
+    # JSON Schema) that openapi consumes without importing this package. Both
+    # namespaces are written this cycle for backward compatibility.
+    set_endpoint_metadata(wrapper, wrapper, build_endpoint_metadata(config))
 
     return wrapper

--- a/tests/test_endpoint_write.py
+++ b/tests/test_endpoint_write.py
@@ -1,0 +1,282 @@
+"""Tests for the ``endpoint`` namespace written by ``validate_http`` (issue #272).
+
+These assert that the decorator emits ``_azure_functions_metadata["endpoint"]``
+alongside the existing ``validation`` namespace, that the payload validates
+against the shipped ``endpoint.schema.json`` for every model combination, and
+that the SPEC canonicalization rules (aliases, request/response mode, $defs,
+request_body_required) are honoured.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+import azure.functions as func
+import jsonschema
+from pydantic import BaseModel, Field
+
+from azure_functions_validation import validate_http
+from azure_functions_validation._endpoint import (
+    ENDPOINT_NAMESPACE,
+    build_endpoint_metadata,
+)
+from azure_functions_validation._metadata import METADATA_ATTR, NAMESPACE
+from azure_functions_validation.schemas import (
+    ENDPOINT_METADATA_VERSION,
+    _contains_ref,
+    assert_defs_present_if_ref_used,
+    load_endpoint_schema,
+)
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+
+
+class CreateUser(BaseModel):
+    name: str = Field(alias="fullName")
+    email: str
+    address: Address
+    nickname: str | None = None
+
+
+class AllOptional(BaseModel):
+    a: str = "x"
+    b: int = 0
+
+
+class UserResponse(BaseModel):
+    id: int
+    name: str
+
+
+class ListQuery(BaseModel):
+    limit: int = 10
+    cursor: str | None = None
+
+
+class PathParams(BaseModel):
+    user_id: int
+
+
+class Headers(BaseModel):
+    x_token: str = Field(alias="x-token")
+
+
+def _endpoint_of(handler: Any) -> dict[str, Any]:
+    meta = getattr(handler, METADATA_ATTR)
+    return cast("dict[str, Any]", meta[ENDPOINT_NAMESPACE])
+
+
+def _validate(payload: Mapping[str, Any]) -> None:
+    jsonschema.validate(payload, load_endpoint_schema())
+
+
+# ---------------------------------------------------------------------------
+# Namespace presence / backward compat
+# ---------------------------------------------------------------------------
+
+
+class TestNamespaceEmission:
+    def test_both_namespaces_written(self) -> None:
+        @validate_http(body=CreateUser, response_model=UserResponse)
+        def handler(req: func.HttpRequest, body: CreateUser) -> UserResponse:
+            return UserResponse(id=1, name=body.name)
+
+        meta = getattr(handler, METADATA_ATTR)
+        assert NAMESPACE in meta
+        assert ENDPOINT_NAMESPACE in meta
+
+    def test_version_matches_constant(self) -> None:
+        @validate_http(body=CreateUser)
+        def handler(req: func.HttpRequest, body: CreateUser) -> Any:
+            return {}
+
+        assert _endpoint_of(handler)["version"] == ENDPOINT_METADATA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Schema validity across combinations
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaValidity:
+    def test_body_only(self) -> None:
+        @validate_http(body=CreateUser)
+        def handler(req: func.HttpRequest, body: CreateUser) -> Any:
+            return {}
+
+        _validate(_endpoint_of(handler))
+
+    def test_full_combination(self) -> None:
+        @validate_http(
+            body=CreateUser,
+            query=ListQuery,
+            path=PathParams,
+            headers=Headers,
+            response_model=UserResponse,
+            status_code=201,
+        )
+        def handler(req: func.HttpRequest, body: CreateUser) -> UserResponse:
+            return UserResponse(id=1, name=body.name)
+
+        payload = _endpoint_of(handler)
+        _validate(payload)
+        assert set(payload["responses"]) == {"201"}
+
+    def test_no_models(self) -> None:
+        @validate_http()
+        def handler(req: func.HttpRequest) -> Any:
+            return {}
+
+        payload = _endpoint_of(handler)
+        _validate(payload)
+        assert payload["request_body"] is None
+        assert payload["request_body_required"] is False
+        assert payload["parameters"] == []
+        assert payload["responses"] is None
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization rules
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalization:
+    def test_request_body_keeps_defs_and_ref(self) -> None:
+        @validate_http(body=CreateUser)
+        def handler(req: func.HttpRequest, body: CreateUser) -> Any:
+            return {}
+
+        rb = _endpoint_of(handler)["request_body"]
+        assert "$defs" in rb
+        assert "Address" in rb["$defs"]
+        # Structural invariant holds.
+        assert_defs_present_if_ref_used(rb)
+
+    def test_request_body_uses_alias(self) -> None:
+        @validate_http(body=CreateUser)
+        def handler(req: func.HttpRequest, body: CreateUser) -> Any:
+            return {}
+
+        rb = _endpoint_of(handler)["request_body"]
+        assert "fullName" in rb["properties"]
+        assert "name" not in rb["properties"]
+
+    def test_request_body_required_true_when_field_required(self) -> None:
+        @validate_http(body=CreateUser)
+        def handler(req: func.HttpRequest, body: CreateUser) -> Any:
+            return {}
+
+        assert _endpoint_of(handler)["request_body_required"] is True
+
+    def test_request_body_required_false_when_all_optional(self) -> None:
+        @validate_http(body=AllOptional)
+        def handler(req: func.HttpRequest, body: AllOptional) -> Any:
+            return {}
+
+        assert _endpoint_of(handler)["request_body_required"] is False
+
+    def test_path_parameter_always_required(self) -> None:
+        @validate_http(path=PathParams)
+        def handler(req: func.HttpRequest) -> Any:
+            return {}
+
+        params = _endpoint_of(handler)["parameters"]
+        assert params == [
+            {
+                "name": "user_id",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "integer", "title": "User Id"},
+            }
+        ]
+
+    def test_query_optional_parameter_not_required(self) -> None:
+        @validate_http(query=ListQuery)
+        def handler(req: func.HttpRequest) -> Any:
+            return {}
+
+        params = {p["name"]: p for p in _endpoint_of(handler)["parameters"]}
+        assert params["limit"]["required"] is False
+        assert params["cursor"]["required"] is False
+        assert all(p["in"] == "query" for p in params.values())
+
+    def test_header_parameter_uses_alias(self) -> None:
+        @validate_http(headers=Headers)
+        def handler(req: func.HttpRequest) -> Any:
+            return {}
+
+        params = _endpoint_of(handler)["parameters"]
+        assert params[0]["name"] == "x-token"
+        assert params[0]["in"] == "header"
+
+    def test_response_uses_serialization_mode(self) -> None:
+        @validate_http(response_model=UserResponse)
+        def handler(req: func.HttpRequest) -> UserResponse:
+            return UserResponse(id=1, name="a")
+
+        responses = _endpoint_of(handler)["responses"]
+        assert set(responses) == {"200"}
+        assert responses["200"]["schema"]["properties"].keys() == {"id", "name"}
+
+
+# ---------------------------------------------------------------------------
+# builder unit coverage (non-model inputs)
+# ---------------------------------------------------------------------------
+
+
+class _Config:
+    def __init__(self, **kw: Any) -> None:
+        self.body = kw.get("body")
+        self.query = kw.get("query")
+        self.path = kw.get("path")
+        self.headers = kw.get("headers")
+        self.response_model = kw.get("response_model")
+        self.success_status_code = kw.get("success_status_code", 200)
+
+
+class TestBuilderDirect:
+    def test_non_model_inputs_are_ignored(self) -> None:
+        payload = build_endpoint_metadata(
+            _Config(body="not a model", query=None, response_model=object())
+        )
+        _validate(payload)
+        assert payload["request_body"] is None
+        assert payload["parameters"] == []
+        assert payload["responses"] is None
+
+    def test_falsy_status_code_defaults_to_200(self) -> None:
+        payload = build_endpoint_metadata(
+            _Config(response_model=UserResponse, success_status_code=0)
+        )
+        assert set(payload["responses"] or {}) == {"200"}
+
+    def test_nested_model_param_attaches_defs(self) -> None:
+        class NestedQuery(BaseModel):
+            addr: Address
+
+        payload = build_endpoint_metadata(_Config(query=NestedQuery))
+        _validate(payload)
+        schema = payload["parameters"][0]["schema"]
+        assert "$defs" in schema
+        assert_defs_present_if_ref_used(schema)
+
+
+class TestContainsRef:
+    def test_ref_nested_in_list(self) -> None:
+        node = {"anyOf": [{"type": "null"}, {"$ref": "#/$defs/Address"}]}
+        assert _contains_ref(node) is True
+
+    def test_no_ref_in_nested_dict(self) -> None:
+        node = {"type": "object", "properties": {"name": {"type": "string"}}}
+        assert _contains_ref(node) is False
+
+    def test_scalar_is_not_a_ref(self) -> None:
+        assert _contains_ref("string") is False
+        assert _contains_ref(42) is False


### PR DESCRIPTION
## Context
Implements #272 (child of #270). `@validate_http` now writes a shared, versioned, self-contained **`endpoint`** metadata namespace onto the wrapped handler, alongside the existing `validation` namespace. The `endpoint` payload is pure JSON Schema, so `azure-functions-openapi` can consume OpenAPI-ready metadata **without importing this package or the user's Pydantic model classes**.

Payload shape and canonicalization are pinned by `schemas/endpoint.schema.json` (schema v1, from #271 / PR #274) and documented in `docs/METADATA_SPEC.md`.

> Stacked on `feat/271-endpoint-schema` (PR #274). Base retargets to `main` once #274 merges.

## What changed
- **`_endpoint.py`** (new): `build_endpoint_metadata(config)` + `set_endpoint_metadata(...)`. Emits `request_body`, `request_body_required`, `parameters`, `responses` as self-contained JSON Schema.
  - `by_alias=True` everywhere (wire-contract names, e.g. `fullName`, `x-token`).
  - `request_body_required` = `any(field.is_required())`; `body=None → (None, False)`.
  - `path` parameters always required; response uses `serialization` mode, request uses `validation` mode.
  - `$defs`-if-`$ref` invariant preserved per-parameter so openapi remains the sole `$ref`-collision authority.
- **`_metadata.py`**: extracted shared `_merge_namespace(...)`; `set_validation_metadata` delegates to it. No clobbering of other namespaces / prior decorators.
- **`decorator.py`**: `_make_wrapper` writes both namespaces (backward compatible).
- **`docs/METADATA_SPEC.md`**: response-object example clarified (`description` optional; omitted in v1).
- **`tests/test_endpoint_write.py`** (new): 19 tests — namespace emission, schema validity across body/query/path/headers/response combos, canonicalization (aliases, nested-model `$defs`, `request_body_required`), builder edge cases, and `_contains_ref`.

## Verification
- `make check-all` green (lint/typecheck/tests/security + `check-schema-hash`).
- 289 passed, 6 skipped; coverage **98.29%** (gate 95%); `_endpoint.py` fully covered.
- Oracle design: "Proceed." Oracle review: **95/100**, no blocking issues (both nits addressed: deduped `_contains_ref`, fixed SPEC example).

## Acceptance Checklist
- [x] `endpoint` namespace written for all input combinations, validates against `endpoint.schema.json`
- [x] Self-contained (no model classes / package import required by consumer)
- [x] `validation` namespace preserved (backward compatible)
- [x] Coverage ≥95%, `make check-all` passes