### PR TITLE
test(metadata): add _metadata_helpers byte-identical drift test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Pin line endings to LF for the byte-identical worker-compat helper so its
+# sha256 stays stable across platforms and checkouts. Guarded by
+# tests/test_metadata_helpers_drift.py. See issue #273.
+src/azure_functions_validation/_metadata_helpers.py text eol=lf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,20 @@ security = "python -m bandit -r src"
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+# Honor `exclude` lists even when ruff is invoked with explicit file paths
+# (e.g. the pre-commit ruff-format hook, which passes staged filenames). This
+# keeps _metadata_helpers.py's format-exclude effective in every invocation.
+# Linting is unaffected: `[tool.ruff.lint]` has no exclude, so the file is
+# still linted; only formatting is skipped for it (see #273).
+force-exclude = true
+
+[tool.ruff.format]
+# _metadata_helpers.py is byte-identical across sibling packages (see #273).
+# Exclude it from formatting so `ruff format` can never silently break the
+# byte-identity invariant guarded by tests/test_metadata_helpers_drift.py.
+exclude = ["src/azure_functions_validation/_metadata_helpers.py"]
+
+
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]

--- a/tests/test_metadata_helpers_drift.py
+++ b/tests/test_metadata_helpers_drift.py
@@ -1,0 +1,50 @@
+"""Byte-identity drift guard for ``_metadata_helpers.py``.
+
+``src/azure_functions_validation/_metadata_helpers.py`` is intentionally kept
+**byte-identical** across sibling DX Toolkit packages (notably
+``azure-functions-validation`` and ``azure-functions-logging``). The primitive
+is hand-synced rather than shared via a runtime import, because these packages
+are independent PyPI distributions with no common base dependency (sharing was
+explicitly rejected in umbrella issue #270).
+
+This test locks the invariant: any accidental edit or reformat of the file
+flips the pinned hash and fails CI. When you *intentionally* change the file:
+
+1. Apply the identical change to the mirror in ``azure-functions-logging``.
+2. Update ``EXPECTED_SHA256`` below **and** the logging repo's mirror test to
+   the new hash in lockstep.
+
+The file is also excluded from ``ruff format`` (see ``[tool.ruff.format]`` in
+``pyproject.toml``) and pinned to LF line endings (see ``.gitattributes``) so
+formatters and platform checkouts cannot silently break byte-identity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from azure_functions_validation import _metadata_helpers
+
+# Pinned sha256 of the raw file bytes.
+#
+# Mirror: azure-functions-logging tests/test_metadata_helpers_drift.py MUST
+# assert this exact same hash so drift in EITHER repository fails.
+EXPECTED_SHA256 = "a3bde2d205f115faf225222dcbea503eb133f298ef8b8d2587d6030a72944287"
+
+_HELPERS_PATH = Path(_metadata_helpers.__file__)
+
+
+def test_metadata_helpers_is_byte_identical() -> None:
+    """The raw bytes of ``_metadata_helpers.py`` match the pinned hash."""
+    digest = hashlib.sha256(_HELPERS_PATH.read_bytes()).hexdigest()
+    assert digest == EXPECTED_SHA256, (
+        "_metadata_helpers.py drifted from its pinned byte-identical hash. "
+        "If this change is intentional, mirror it into azure-functions-logging "
+        "and update EXPECTED_SHA256 in BOTH repos in lockstep. See #273 / #270."
+    )
+
+
+def test_metadata_helpers_uses_lf_line_endings() -> None:
+    """No CRLF bytes — LF is required for cross-platform byte-identity."""
+    assert b"\r\n" not in _HELPERS_PATH.read_bytes()

--- a/tests/test_metadata_helpers_drift.py
+++ b/tests/test_metadata_helpers_drift.py
@@ -32,6 +32,9 @@ from azure_functions_validation import _metadata_helpers
 # assert this exact same hash so drift in EITHER repository fails.
 EXPECTED_SHA256 = "a3bde2d205f115faf225222dcbea503eb133f298ef8b8d2587d6030a72944287"
 
+# ``ModuleType.__file__`` is typed ``str | None``; for an imported source module
+# it is always set, but assert to keep mypy --strict happy.
+assert _metadata_helpers.__file__ is not None
 _HELPERS_PATH = Path(_metadata_helpers.__file__)
 
 


### PR DESCRIPTION
## Context
Implements #273 (child of #270). `src/azure_functions_validation/_metadata_helpers.py` is intentionally **byte-identical** across sibling DX Toolkit packages (`azure-functions-validation`, `azure-functions-logging`), hand-synced rather than shared via a runtime import (sharing was explicitly rejected in #270). This adds guardrails so an accidental edit or reformat in either repo is caught.

> Stacked on `feat/272-write-endpoint-metadata` (PR #275). Base retargets as the stack merges.

## What changed
- **`tests/test_metadata_helpers_drift.py`** (new): hashes the file's **raw bytes** (`sha256`) and asserts it matches a pinned constant; a second test rejects CRLF. Module docstring documents the lockstep sync obligation; a comment at `EXPECTED_SHA256` instructs the logging repo's mirror test to assert the identical hash (bidirectional pin).
- **`pyproject.toml`**: `[tool.ruff.format].exclude` for the file + `force-exclude = true`, so `ruff format` cannot touch it in **any** invocation (including the pre-commit `ruff-format` hook, which passes explicit filenames). Linting still runs on the file (`[tool.ruff.lint]` has no exclude).
- **`.gitattributes`** (new): `text eol=lf` pins line endings so byte-identity holds across platforms/checkouts.

## Verification
- `make check-all` green (lint/typecheck/tests/security + coverage ≥95%).
- Confirmed: explicit-path `ruff format` **skips** the file (force-exclude) while `ruff check` still lints it.
- Oracle design: APPROVE. Oracle review: **95/100**, no blocking issues. The one substantive nit (explicit-path format bypass) is resolved by `force-exclude = true` after confirming a pre-commit `ruff-format` hook exists.

## Acceptance Checklist
- [x] Hash test pins `_metadata_helpers.py` raw-bytes sha256
- [x] File excluded from ruff formatting (robust to explicit-path invocations)
- [x] `.gitattributes` pins LF line endings
- [x] Sync obligation documented in test + existing file docstring

## Follow-up (out of scope)
- Add the mirror drift test asserting the same hash in `azure-functions-logging` (tracked under #270).