### PR TITLE
feat(decorator): warn when @validate_http is applied above @with_context (#277)

### DIFF
--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -9,7 +9,7 @@ import warnings
 from pydantic import TypeAdapter
 
 from ._endpoint import build_endpoint_metadata, set_endpoint_metadata
-from ._metadata import ValidationMetadata, set_validation_metadata
+from ._metadata import METADATA_ATTR, ValidationMetadata, set_validation_metadata
 from ._metadata_helpers import SAFE_IDENTITY_ATTRS, copy_identity_attrs
 from .adapter import PydanticAdapter, ValidationAdapter
 from .errors import ErrorFormatter
@@ -87,6 +87,19 @@ def validate_http(
             )
             return func
 
+        # Cross-repo decorator-order guard (azure-functions-logging#310).
+        if _has_logging_metadata(func):
+            warnings.warn(
+                "@validate_http is applied ABOVE @with_context (from "
+                "azure-functions-logging). In this order, validation error "
+                "responses (e.g. 4xx) are produced before @with_context runs, so "
+                "they are logged WITHOUT correlation context. Place @with_context "
+                "ABOVE @validate_http (outermost, just under @app.route) so it "
+                "wraps the validated handler.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
         is_async = inspect.iscoroutinefunction(func)
 
         func_sig = inspect.signature(func)
@@ -137,6 +150,25 @@ def _is_function_builder(func: Any) -> bool:
     if _FunctionBuilder is not None and isinstance(func, _FunctionBuilder):
         return True
     return type(func).__name__ == "FunctionBuilder"
+
+
+#: Namespace key written by ``azure-functions-logging``'s ``@with_context``.
+#: Matched as a literal string (no import of that package) per the shared
+#: ``_azure_functions_metadata`` contract. See azure-functions-logging#310.
+_LOGGING_NAMESPACE = "logging"
+
+
+def _has_logging_metadata(func: Any) -> bool:
+    """Return ``True`` if *func* already carries logging (``@with_context``) metadata.
+
+    This happens only when ``@with_context`` was applied *before* (inner to)
+    ``@validate_http`` — i.e. ``@validate_http`` is above ``@with_context``, the
+    wrong order. Detection reads the shared ``_azure_functions_metadata`` dict for
+    the ``"logging"`` namespace using the literal key, without importing the
+    logging package.
+    """
+    metadata = getattr(func, METADATA_ATTR, None)
+    return isinstance(metadata, dict) and _LOGGING_NAMESPACE in metadata
 
 
 def _find_request_param(

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -5,11 +5,16 @@ Runtime pipeline behaviour (parsing, response building) is tested in
 that happens when ``@validate_http(...)`` is applied to a function.
 """
 
+from collections.abc import Callable
+from typing import TypeVar
+
 from azure.functions import HttpRequest, HttpResponse
 from pydantic import BaseModel, Field
 import pytest
 
 from azure_functions_validation import validate_http
+
+_HandlerT = TypeVar("_HandlerT", bound=Callable[..., object])
 
 # ---------------------------------------------------------------------------
 # Minimal models used by configuration tests
@@ -252,7 +257,7 @@ class TestLoggingDecoratorOrder:
     """@validate_http above @with_context must warn (validation errors lose context)."""
 
     @staticmethod
-    def _with_logging_metadata(handler: object) -> object:
+    def _with_logging_metadata(handler: _HandlerT) -> _HandlerT:
         """Simulate ``@with_context`` having run first (inner) on *handler*."""
         from azure_functions_validation._metadata import METADATA_ATTR
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -246,3 +246,82 @@ class TestWrongDecoratorOrder:
         wrapped = validate_http(body=UserModel)(handler)
         assert wrapped is not handler
         assert not any(issubclass(w.category, RuntimeWarning) for w in recwarn.list)
+
+
+class TestLoggingDecoratorOrder:
+    """@validate_http above @with_context must warn (validation errors lose context)."""
+
+    @staticmethod
+    def _with_logging_metadata(handler: object) -> object:
+        """Simulate ``@with_context`` having run first (inner) on *handler*."""
+        from azure_functions_validation._metadata import METADATA_ATTR
+
+        setattr(
+            handler,
+            METADATA_ATTR,
+            {"logging": {"version": 1, "context_param": "context"}},
+        )
+        return handler
+
+    def test_warns_when_logging_metadata_present(self) -> None:
+        """Wrong order: @with_context applied inner leaves a ``logging`` namespace."""
+
+        def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
+            return HttpResponse("ok")
+
+        inner = self._with_logging_metadata(handler)
+        with pytest.warns(RuntimeWarning, match=r"@with_context"):
+            wrapped = validate_http(body=UserModel)(inner)
+        assert wrapped is not inner
+
+    def test_warns_for_async_handler(self) -> None:
+        """The guard fires before sync/async dispatch, so async handlers warn too."""
+
+        async def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
+            return HttpResponse("ok")
+
+        inner = self._with_logging_metadata(handler)
+        with pytest.warns(RuntimeWarning, match=r"@with_context"):
+            wrapped = validate_http(body=UserModel)(inner)
+        assert wrapped is not inner
+
+
+    def test_warns_preserves_logging_namespace(self) -> None:
+        """The wrapper keeps the pre-existing ``logging`` namespace (merge, no clobber)."""
+        from azure_functions_validation._metadata import METADATA_ATTR
+
+        def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
+            return HttpResponse("ok")
+
+        inner = self._with_logging_metadata(handler)
+        with pytest.warns(RuntimeWarning, match=r"@with_context"):
+            wrapped = validate_http(body=UserModel)(inner)
+        meta = getattr(wrapped, METADATA_ATTR)
+        assert "logging" in meta
+        assert "validation" in meta
+
+    def test_no_warning_for_correct_order(
+        self, recwarn: pytest.WarningsRecorder
+    ) -> None:
+        """Correct order: @validate_http runs first, sees no ``logging`` namespace."""
+
+        def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
+            return HttpResponse("ok")
+
+        wrapped = validate_http(body=UserModel)(handler)
+        assert wrapped is not handler
+        assert not any(issubclass(w.category, RuntimeWarning) for w in recwarn.list)
+
+    def test_no_warning_for_unrelated_namespace(
+        self, recwarn: pytest.WarningsRecorder
+    ) -> None:
+        """A non-logging namespace (e.g. another sibling) must not trigger the warning."""
+        from azure_functions_validation._metadata import METADATA_ATTR
+
+        def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
+            return HttpResponse("ok")
+
+        setattr(handler, METADATA_ATTR, {"openapi": {"version": 1}})
+        wrapped = validate_http(body=UserModel)(handler)
+        assert wrapped is not handler
+        assert not any(issubclass(w.category, RuntimeWarning) for w in recwarn.list)


### PR DESCRIPTION
## Summary
Implements the authoritative wrong-order guard for the `@with_context` / `@validate_http` decorator pair (umbrella #270; sibling of azure-functions-logging#310).

Correct order is `@with_context` (outer) / `@validate_http` (inner) so validation 4xx errors are logged with correlation context. Per the Oracle design gate, the wrong order cannot be reliably detected from `@with_context` (a solo `@with_context` is indistinguishable from the wrong-order case), but **can** be detected authoritatively here: when `@validate_http` receives a handler that already carries the `"logging"` namespace in `_azure_functions_metadata`, `@with_context` ran first (inner) = wrong order.

- `@validate_http` emits a `RuntimeWarning` (decoration-time, `stacklevel=2`) explaining the correct order + consequence.
- Does **not** reorder or short-circuit; wrapping proceeds so validation still works (only logging correlation is lost, matching the message).
- Detection uses the shared metadata contract via the literal `"logging"` key — **no import** of azure-functions-logging (the contract is published by logging#310).
- No false positives: solo `@validate_http` and the correct order never see a `"logging"` key.

## Tests (5 new, `TestLoggingDecoratorOrder`)
- Wrong order (sync + async) warns and still wraps.
- Wrapper preserves both `logging` and `validation` namespaces (merge, no clobber).
- Correct order → no warning.
- Unrelated namespace (`openapi`) → no warning.

## Verification
- `make check-all` green — 255 passed, coverage 97.97% (gate 95%), ruff + mypy strict + bandit clean.

## Review
Oracle design gate + implementation review: **92/100 SHIP**.

Closes #277. Refs #270, azure-functions-logging#310