### PR TITLE
chore(deps): cap azure-functions below 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "azure-functions>=1.17",
+    "azure-functions>=1.17,<2.0.0",
     "pydantic>=2.0,<3.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
 ]
 
 dependencies = [
+    # Cap below 2.0.0: azure-functions v2 may change worker function-indexing
+    # behavior this package relies on. See knowledge#46 / dx#8.
     "azure-functions>=1.17,<2.0.0",
     "pydantic>=2.0,<3.0",
 ]


### PR DESCRIPTION
## Context
Part of the DX Toolkit dependency-bound unification tracked in yeongseon/azure-functions-python-dx#8. `azure-functions` was pinned with a lower bound only (`>=1.17`), so a future `azure-functions` 2.x major could be installed and silently break the decorator's worker-compatibility assumptions.

## Changes
- `pyproject.toml`: `azure-functions>=1.17` → `azure-functions>=1.17,<2.0.0`.

## Verification
- `make check-all` → EXIT=0 (296 passed, 6 skipped, coverage 98.32%).

Refs yeongseon/azure-functions-python-dx#8