### PR TITLE
feat(endpoint): include 422 validation-error response in endpoint namespace

### DIFF
--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -51,7 +51,8 @@ drift.
     { "name": "id", "in": "path", "required": true, "schema": { /* JSON Schema */ } }
   ],
   "responses": {                    // status-code (string) -> response object; or null
-    "200": { "schema": { /* JSON Schema */ } }  // "description" optional; producer omits it in v1
+    "200": { "schema": { /* JSON Schema */ } },  // "description" optional; producer omits it in v1
+    "422": { "schema": { /* validation-error envelope */ } } // present when request validation applies
   } | null,
   "summary": "…",                   // optional
   "description": "…",               // optional
@@ -65,6 +66,43 @@ drift.
 The Azure Functions route binding (`@app.route(route=…, methods=…)`) is the
 single source of truth for path and HTTP methods. The consumer derives them at
 scan time from the binding, so producers must not duplicate them here.
+
+### The `422` validation-error response
+
+When the operation performs request validation — i.e. any of `body`, `query`,
+`path`, or `headers` is a Pydantic model — producers MUST add a `"422"` entry to
+`responses` describing the standardized validation-error body the runtime
+returns on invalid input:
+
+```jsonc
+{
+  "type": "object",
+  "required": ["detail"],
+  "properties": {
+    "detail": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "properties": {
+          "loc": { "type": "array", "items": { "type": ["string", "integer"] } },
+          "msg": { "type": "string" },
+          "type": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+```
+
+The `422` schema is **self-contained** (no `$ref`, no `$defs`). It is emitted
+independently of `response_model`: an operation with a request model but no
+`response_model` still carries a `responses` map of just `{"422": …}`. When
+there is no request model, no `422` is emitted. This documents the default
+`{"detail": [...]}` envelope only; a custom `ErrorFormatter` may change the
+runtime body without changing this schema. Adding `422` is an additive change
+and does not bump the namespace version.
+
 
 ## Canonicalization rules (producers MUST follow)
 

--- a/src/azure_functions_validation/_endpoint.py
+++ b/src/azure_functions_validation/_endpoint.py
@@ -31,6 +31,43 @@ ENDPOINT_NAMESPACE = "endpoint"
 #: consumer (openapi) remains the sole ``$ref``-collision authority.
 _REF_TEMPLATE = "#/$defs/{model}"
 
+#: HTTP status code under which the standardized validation-error response is
+#: documented. Emitted whenever request validation can fail (any of
+#: ``body``/``query``/``path``/``headers`` is a model).
+_VALIDATION_ERROR_STATUS = "422"
+
+
+def _validation_error_schema() -> dict[str, Any]:
+    """Return a self-contained JSON Schema for the ``{"detail": [...]}`` envelope.
+
+    Mirrors the runtime 422 body produced by the pipeline (see
+    ``pipeline.format_error_response``): a ``detail`` array of items with
+    ``loc`` / ``msg`` / ``type``. A fresh dict is built on every call so
+    consumers may mutate the embedded schema freely without cross-handler
+    aliasing. Contains no ``$ref``, so the ``$defs``-if-``$ref`` rule does not
+    apply.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "detail": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "type": "array",
+                            "items": {"type": ["string", "integer"]},
+                        },
+                        "msg": {"type": "string"},
+                        "type": {"type": "string"},
+                    },
+                    "required": ["loc", "msg", "type"],
+                },
+            }
+        },
+        "required": ["detail"],
+    }
 
 class EndpointMetadata(TypedDict, total=False):
     """Shape of ``_azure_functions_metadata["endpoint"]`` (schema version 1)."""
@@ -112,29 +149,35 @@ def build_endpoint_metadata(config: Any) -> EndpointMetadata:
         request_body_required = False
 
     parameters: list[dict[str, Any]] = []
+    has_request_model = False
     for model, location in (
         (config.query, "query"),
         (config.path, "path"),
         (config.headers, "header"),
     ):
         if _is_model_type(model):
+            has_request_model = True
             parameters.extend(_build_parameters(model, location))
 
+    # A request body model also makes request validation (and thus a 422) possible.
+    has_request_model = has_request_model or _is_model_type(body)
+
+    responses: dict[str, dict[str, Any]] = {}
     response_model = config.response_model
     if _is_model_type(response_model):
         status = str(getattr(config, "success_status_code", 200) or 200)
-        responses: dict[str, dict[str, Any]] | None = {
-            status: {"schema": _model_schema(response_model, "serialization")}
-        }
-    else:
-        responses = None
+        responses[status] = {"schema": _model_schema(response_model, "serialization")}
+    if has_request_model:
+        # Document the standardized validation-error contract the runtime emits
+        # on invalid input, so consumers (openapi) need not hand-author it.
+        responses[_VALIDATION_ERROR_STATUS] = {"schema": _validation_error_schema()}
 
     payload: EndpointMetadata = {
         "version": ENDPOINT_METADATA_VERSION,
         "request_body": request_body,
         "request_body_required": request_body_required,
         "parameters": parameters,
-        "responses": responses,
+        "responses": responses or None,
     }
     return payload
 

--- a/tests/test_endpoint_write.py
+++ b/tests/test_endpoint_write.py
@@ -9,6 +9,7 @@ request_body_required) are honoured.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Mapping, cast
 
 import azure.functions as func
@@ -127,7 +128,7 @@ class TestSchemaValidity:
 
         payload = _endpoint_of(handler)
         _validate(payload)
-        assert set(payload["responses"]) == {"201"}
+        assert set(payload["responses"]) == {"201", "422"}
 
     def test_no_models(self) -> None:
         @validate_http()
@@ -140,6 +141,77 @@ class TestSchemaValidity:
         assert payload["request_body_required"] is False
         assert payload["parameters"] == []
         assert payload["responses"] is None
+
+
+# ---------------------------------------------------------------------------
+# 422 validation-error response (issue #283)
+# ---------------------------------------------------------------------------
+
+
+class TestValidationErrorResponse:
+    def test_body_only_emits_422(self) -> None:
+        @validate_http(body=CreateUser)
+        def handler(req: func.HttpRequest, body: CreateUser) -> Any:
+            return {}
+
+        payload = _endpoint_of(handler)
+        _validate(payload)
+        assert set(payload["responses"]) == {"422"}
+
+    def test_query_only_emits_422(self) -> None:
+        @validate_http(query=ListQuery)
+        def handler(req: func.HttpRequest) -> Any:
+            return {}
+
+        assert set(_endpoint_of(handler)["responses"]) == {"422"}
+
+    def test_success_and_422_coexist(self) -> None:
+        @validate_http(body=CreateUser, response_model=UserResponse, status_code=201)
+        def handler(req: func.HttpRequest, body: CreateUser) -> UserResponse:
+            return UserResponse(id=1, name=body.name)
+
+        assert set(_endpoint_of(handler)["responses"]) == {"201", "422"}
+
+    def test_response_model_only_has_no_422(self) -> None:
+        @validate_http(response_model=UserResponse)
+        def handler(req: func.HttpRequest) -> UserResponse:
+            return UserResponse(id=1, name="a")
+
+        assert set(_endpoint_of(handler)["responses"]) == {"200"}
+
+    def test_no_models_has_no_responses(self) -> None:
+        @validate_http()
+        def handler(req: func.HttpRequest) -> Any:
+            return {}
+
+        assert _endpoint_of(handler)["responses"] is None
+
+    def test_422_schema_matches_detail_envelope(self) -> None:
+        @validate_http(body=CreateUser)
+        def handler(req: func.HttpRequest, body: CreateUser) -> Any:
+            return {}
+
+        schema = _endpoint_of(handler)["responses"]["422"]["schema"]
+        assert schema["required"] == ["detail"]
+        item = schema["properties"]["detail"]["items"]
+        assert set(item["required"]) == {"loc", "msg", "type"}
+        # Self-contained: no $ref, so the $defs-if-$ref rule is a no-op.
+        assert "$ref" not in json.dumps(schema)
+        assert_defs_present_if_ref_used(schema)
+
+    def test_422_schema_is_fresh_copy_per_handler(self) -> None:
+        @validate_http(body=CreateUser)
+        def handler_a(req: func.HttpRequest, body: CreateUser) -> Any:
+            return {}
+
+        @validate_http(body=CreateUser)
+        def handler_b(req: func.HttpRequest, body: CreateUser) -> Any:
+            return {}
+
+        schema_a = _endpoint_of(handler_a)["responses"]["422"]["schema"]
+        schema_b = _endpoint_of(handler_b)["responses"]["422"]["schema"]
+        schema_a["properties"]["detail"]["_marker"] = True
+        assert "_marker" not in schema_b["properties"]["detail"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `build_endpoint_metadata` now emits a self-contained `"422"` entry in the `responses` map whenever a request model (`body`/`query`/`path`/`headers`) is present, documenting the standardized `{"detail": [{"loc","msg","type"}]}` validation-error envelope returned at runtime by `@validate_http`.
- Additive change — `ENDPOINT_METADATA_VERSION` stays at 1; consumers read defensively via `.get()`.
- `docs/METADATA_SPEC.md` updated to document the 422 response shape; new unit tests in `tests/test_endpoint_write.py` assert the `responses` map contains both the success status and `"422"` with the correct schema.

## Verification
- `make check-all` green (fresh hatch env): 303 passed, 6 skipped.
- Coverage 98.34% (>= 95%).
- No README changes → no translation sync required (only internal `METADATA_SPEC.md` touched).

Closes #283