### PR TITLE
docs(metadata): separate generic endpoint convention from validation-specific 422/Pydantic rules

### DIFF
--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -142,6 +142,10 @@ requires plain JSON Schema with `$defs` left unresolved:
 | Generator class | Pydantic default `GenerateJsonSchema` (pin explicitly if customized; Pydantic minor bumps can change output) |
 | `request_body_required` | `True` unless every field of the body model has a default |
 
+The response-schema mode above applies to **Pydantic-derived response-model
+schemas**. The `422` validation-error response schema is produced directly
+(not from a Pydantic model) and is unaffected by these settings.
+
 ### Structural rule: `$defs` if `$ref`
 
 Any embedded schema that contains a `$ref` **anywhere** MUST carry a top-level

--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -2,8 +2,9 @@
 
 Status: **v1** · Owner namespace: `endpoint` · Issue: [#271](https://github.com/yeongseon/azure-functions-validation-python/issues/271) · Umbrella: [#270](https://github.com/yeongseon/azure-functions-validation-python/issues/270)
 
-> **Localization:** This specification is a canonical, English-only technical
-> document (the machine-readable source of truth is the JSON Schema it links to).
+> **Localization:** This specification is an English-only technical document
+> (the JSON Schema it links to is an internal conformance artifact of this
+> package, not a source of truth other packages bind to).
 > It is intentionally **not** part of the translated README set
 > (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) and requires no translation
 > updates when it changes.
@@ -55,7 +56,7 @@ its own local conformance tests against the versioned dict convention.
   ],
   "responses": {                    // status-code (string) -> response object; or null
     "200": { "schema": { /* JSON Schema */ } },  // "description" optional; producer omits it in v1
-    "422": { "schema": { /* validation-error envelope */ } } // present when request validation applies
+    "422": { "schema": { /* validation-error envelope */ } } // added by this producer when request validation applies
   } | null,
   "summary": "…",                   // optional
   "description": "…",               // optional
@@ -70,10 +71,27 @@ The Azure Functions route binding (`@app.route(route=…, methods=…)`) is the
 single source of truth for path and HTTP methods. The consumer derives them at
 scan time from the binding, so producers must not duplicate them here.
 
-### The `422` validation-error response
+### `responses` describes the endpoint's actual runtime responses
 
-When the operation performs request validation — i.e. any of `body`, `query`,
-`path`, or `headers` is a Pydantic model — producers MUST add a `"422"` entry to
+`responses` is a **generic** part of the convention: a producer maps each HTTP
+status code it can return to a response object carrying that response's JSON
+Schema, or emits `null` when it has nothing to describe. What those responses
+*are* is producer-specific. A non-Pydantic producer, or one that only emits
+success responses, is under no obligation to document a `422` body — it simply
+describes whatever its runtime actually returns.
+
+## azure-functions-validation implementation
+
+The rest of this document describes rules that are **specific to
+`azure-functions-validation`** — how *this* producer generates its payload. They
+are not obligations on the generic `endpoint` convention above; other producers
+of the namespace implement their own equivalents.
+
+### The `422` validation-error response (validation-specific)
+
+`@validate_http` returns a `422` on request-validation failure, so when the
+operation performs request validation — i.e. any of `body`, `query`, `path`, or
+`headers` is a Pydantic model — **this producer** adds a `"422"` entry to
 `responses` describing the standardized validation-error body the runtime
 returns on invalid input:
 
@@ -107,10 +125,12 @@ runtime body without changing this schema. Adding `422` is an additive change
 and does not bump the namespace version.
 
 
-## Canonicalization rules (producers MUST follow)
+## Canonicalization rules (validation-specific)
 
-Producers generate embedded schemas from Pydantic models with **exactly** these
-settings so output is stable and consumer-mergeable:
+`azure-functions-validation` generates its embedded schemas from Pydantic models
+with **exactly** these settings so output is stable and consumer-mergeable. This
+is how *this* producer happens to canonicalize; the generic convention only
+requires plain JSON Schema with `$defs` left unresolved:
 
 | Rule | Value |
 | --- | --- |

--- a/src/azure_functions_validation/_endpoint.py
+++ b/src/azure_functions_validation/_endpoint.py
@@ -5,14 +5,15 @@ shared ``_azure_functions_metadata`` convention attribute:
 
 * ``"validation"`` — this package's own request/response model references
   (kept for the deprecation cycle; see :mod:`._metadata`).
-* ``"endpoint"`` — the shared, OpenAPI-ready contract consumed by
-  ``azure-functions-openapi``. Unlike the ``validation`` namespace (which
-  carries Pydantic model *classes*), the ``endpoint`` payload is entirely
+* ``"endpoint"`` — this package's local, OpenAPI-ready endpoint payload,
+  consumed by ``azure-functions-openapi``. Unlike the ``validation`` namespace
+  (which carries Pydantic model *classes*), the ``endpoint`` payload is entirely
   *self-contained* JSON Schema: the consumer needs no import of this package
   and no access to the user's model classes.
 
-The payload shape and canonicalization rules are pinned by
-``schemas/endpoint.schema.json`` and documented in ``docs/METADATA_SPEC.md``.
+This package's payload shape and canonicalization rules are checked against
+``schemas/endpoint.schema.json`` — a local conformance artifact — and
+documented in ``docs/METADATA_SPEC.md``.
 """
 
 from __future__ import annotations
@@ -24,11 +25,11 @@ from pydantic import BaseModel
 from ._metadata import _merge_namespace
 from .schemas import ENDPOINT_METADATA_VERSION, _contains_ref
 
-#: Namespace owned by the shared endpoint contract.
+#: Namespace for this package's local endpoint payload.
 ENDPOINT_NAMESPACE = "endpoint"
 
-#: Pydantic ref template pinned by the SPEC so ``$defs`` stay unresolved and the
-#: consumer (openapi) remains the sole ``$ref``-collision authority.
+#: Pydantic ref template used by this producer so ``$defs`` stay unresolved and
+#: the consumer (openapi) remains the sole ``$ref``-collision authority.
 _REF_TEMPLATE = "#/$defs/{model}"
 
 #: HTTP status code under which the standardized validation-error response is
@@ -69,6 +70,7 @@ def _validation_error_schema() -> dict[str, Any]:
         "required": ["detail"],
     }
 
+
 class EndpointMetadata(TypedDict, total=False):
     """Shape of ``_azure_functions_metadata["endpoint"]`` (schema version 1)."""
 
@@ -91,7 +93,6 @@ def _model_schema(model: type[BaseModel], mode: str) -> dict[str, Any]:
         ref_template=_REF_TEMPLATE,
         mode=mode,  # type: ignore[arg-type]
     )
-
 
 
 def _attach_defs_if_ref(

--- a/src/azure_functions_validation/schemas/endpoint.schema.json
+++ b/src/azure_functions_validation/schemas/endpoint.schema.json
@@ -27,7 +27,7 @@
       "items": { "$ref": "#/$defs/parameter" }
     },
     "responses": {
-      "description": "Map of HTTP status code (as string) to a response object carrying the response's JSON Schema; null when the producer has no responses to describe. Response schemas use mode='serialization'.",
+      "description": "Map of HTTP status code (as string) to a response object carrying the response's JSON Schema; null when the producer has no responses to describe. Pydantic-derived response-model schemas use mode='serialization'; other entries (e.g. the 422 validation-error schema) are produced directly and are unaffected.",
       "anyOf": [
         {
           "type": "object",

--- a/src/azure_functions_validation/schemas/endpoint.schema.json
+++ b/src/azure_functions_validation/schemas/endpoint.schema.json
@@ -27,7 +27,7 @@
       "items": { "$ref": "#/$defs/parameter" }
     },
     "responses": {
-      "description": "Map of HTTP status code (as string) to a response object carrying the response model's JSON Schema. null when no response model is declared. Response schemas use mode='serialization'.",
+      "description": "Map of HTTP status code (as string) to a response object carrying the response's JSON Schema; null when the producer has no responses to describe. Response schemas use mode='serialization'.",
       "anyOf": [
         {
           "type": "object",

--- a/src/azure_functions_validation/schemas/endpoint.schema.sha256
+++ b/src/azure_functions_validation/schemas/endpoint.schema.sha256
@@ -1,1 +1,1 @@
-907d0205afe6579386591e5192ffdb4092fcc390ffe218bb13cc531b29ca292f  endpoint.schema.json
+70cf0b93da7e2558484960b7c6a5822c1d2c6dda673ca5fdb627fd03285cd9e7  endpoint.schema.json

--- a/src/azure_functions_validation/schemas/endpoint.schema.sha256
+++ b/src/azure_functions_validation/schemas/endpoint.schema.sha256
@@ -1,1 +1,1 @@
-70cf0b93da7e2558484960b7c6a5822c1d2c6dda673ca5fdb627fd03285cd9e7  endpoint.schema.json
+fda7b9c4ccaca770c4af2c55b7e174f52424f78484af26e8d00360f462cc057e  endpoint.schema.json


### PR DESCRIPTION
## Summary

Restructures `docs/METADATA_SPEC.md` so the generic `endpoint` metadata convention is no longer conflated with `azure-functions-validation`-specific implementation rules:

- **Generic convention** — `responses` now explicitly describes an endpoint's *actual runtime responses*; a non-Pydantic producer (or one emitting only success responses) owes no `422 {"detail": [...]}` body.
- **Validation-specific** — the `422` validation-error response and the Pydantic canonicalization block (`by_alias`, modes, `ref_template`, `GenerateJsonSchema`) are reframed as how *this producer* generates its payload ("this producer MUST", not "producers MUST"), under a dedicated `## azure-functions-validation implementation` section.

Also fixes residual framing from #288:

- `endpoint.schema.json` `responses` description: "null when the producer has no responses to describe" (an operation with a request model but no response model still emits `{"responses": {"422": ...}}`).
- `_endpoint.py:8,14` comments drop the "shared, OpenAPI-ready contract" / "pinned by schema" ownership wording in favor of local producer / local conformance artifact framing (mirrors openapi #336).
- Re-pinned `endpoint.schema.sha256` after the description edit.

## Verification

- No runtime behavior change; `ENDPOINT_METADATA_VERSION` unchanged (all edits are wording/description).
- `make check-all` passes (306 passed, 6 skipped; ruff/mypy/bandit clean; schema-hash pin matches).
- English-only technical doc — not part of the translated README set, no translation impact.

Closes #290