### PR TITLE
refactor(schemas): make internal endpoint-schema surface unambiguous before 1.0

### DIFF
--- a/src/azure_functions_validation/schemas/__init__.py
+++ b/src/azure_functions_validation/schemas/__init__.py
@@ -25,14 +25,9 @@ from importlib import resources
 import json
 from typing import Any
 
-__all__ = [
-    "ENDPOINT_METADATA_VERSION",
-    "ENDPOINT_SCHEMA_FILENAME",
-    "assert_defs_present_if_ref_used",
-    "endpoint_schema_sha256",
-    "load_endpoint_schema",
-    "pinned_endpoint_schema_sha256",
-]
+# NOTE: This subpackage is internal. It deliberately declares no ``__all__`` so
+# none of its names read as a supported public API; sibling packages MUST NOT
+# import from here (see the module docstring and docs/METADATA_SPEC.md).
 
 #: Current version of the ``endpoint`` namespace payload. Bump only on a
 #: breaking payload change; consumers warn (not fail) on unknown versions.


### PR DESCRIPTION
## Summary

Removes the explicit `__all__` from `azure_functions_validation/schemas/__init__.py` (Option B from #291). The subpackage is documented as internal, but declaring `__all__` made its loader symbols (`ENDPOINT_METADATA_VERSION`, `load_endpoint_schema`, `endpoint_schema_sha256`, `assert_defs_present_if_ref_used`, ...) read as a supported public API — an import path we would be reluctant to break at 1.0.

## Why Option B (not the rename)

Keeping the `schemas` module name avoids churning the `importlib.resources` package-data paths that resolve the shipped `endpoint.schema.json` / `.sha256`. Removing `__all__` is sufficient to stop the surface reading as public.

## Verification

- Top-level `azure_functions_validation/__init__.py` does **not** re-export any of these symbols (confirmed); `test_public_api.py` stays green.
- Package-data loading still resolves the shipped schema (no rename).
- `make check-all` passes; coverage stays >= 95%.
- No runtime or payload change; `ENDPOINT_METADATA_VERSION` unchanged.

Closes #291

---
_Supersedes #293 (re-created under a `chore/` branch to satisfy the branch-naming gate; content unchanged)._