### PR TITLE
docs(metadata): drop 'same release train' wording from versioning section

### DIFF
--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -169,8 +169,9 @@ alone and is enforced by
 
 - `version` starts at `1`. Bump only on a **breaking** payload change.
 - Additive, optional fields do **not** bump the version.
-- On a bump, update the schema, its SHA-256 pin, this spec, and every sibling
-  producer/consumer in the same release train.
+- On a bump, update the schema, its SHA-256 pin, and this spec, and coordinate
+  producer/consumer support as needed before shipping the breaking version.
+  Packages release independently — there is no coordinated release train.
 
 ## Internal helpers (not a public API)
 


### PR DESCRIPTION
## Summary

- Rewords the versioning-policy bump guidance in `docs/METADATA_SPEC.md` to reflect **independent per-package releases** rather than a coordinated release train.
- New wording: "coordinate producer/consumer support as needed before shipping the breaking version. Packages release independently — there is no coordinated release train."

## Notes

- Confirmed no other doc implies a coordinated/lockstep release train (`agent-playbook.md`'s "lockstep" refers to tests/docs, not releases — out of scope).
- `docs/METADATA_SPEC.md` has no translated variants, so no translation sync is required.
- No behavioral change to versioning.

Closes #295