### PR TITLE
feat(decorator): let @validate_http compose with extra input/output bindings

### DIFF
--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, get_type_hints
 import warnings
 
 from pydantic import TypeAdapter
@@ -234,26 +234,90 @@ def _validate_no_conflicts(
 _MISSING: Any = object()  # sentinel for absent req argument
 
 
+#: Parameter names the Azure Functions worker injects implicitly (by name),
+#: without a corresponding user-registered binding. These must stay HIDDEN from
+#: the exposed signature or the worker indexer fails (issue #284). ``context``
+#: (``func.Context``) is the canonical example.
+_WORKER_INJECTED_PARAMS: frozenset[str] = frozenset({"context"})
+
+
+def _validation_injected_names(config: Any) -> set[str]:
+    """Return the handler param names that the validation pipeline fills.
+
+    These are the ``@validate_http``-injected inputs (``body``/``query``/``path``/
+    ``headers``/``req_model``/``http_request``). They must be HIDDEN from the
+    worker-visible signature because they have no Azure Functions binding -- the
+    values are derived from the HTTP request, not bound by the worker. Mirrors
+    the injection logic in :mod:`.pipeline` (``_inject_body`` / ``_inject_named``).
+    """
+    fp = config.func_params
+    names: set[str] = set()
+    if config.body is not None:
+        if "body" in fp:
+            names.add("body")
+        elif "req_model" in fp and config.request_model is not None:
+            names.add("req_model")
+    if config.query is not None and "query" in fp:
+        names.add("query")
+    if config.path is not None and "path" in fp:
+        names.add("path")
+    if config.headers is not None and "headers" in fp:
+        names.add("headers")
+    if "http_request" in fp and config.request_param_name != "http_request":
+        names.add("http_request")
+    return names
+
+
+def _passthrough_params(config: Any) -> list[tuple[str, inspect.Parameter]]:
+    """Return handler params the worker must still see and bind (issue #297).
+
+    Passthrough params are the extra input/output binding params a handler may
+    declare alongside ``req`` -- e.g. ``@app.durable_client_input`` (``client``)
+    or ``@app.cosmos_db_output`` (``order_doc``). The worker indexer matches
+    these to their registered bindings BY NAME, so they must appear in the
+    exposed signature. Excluded are: the HTTP request param (exposed as ``req``),
+    the validation-injected params, the implicitly worker-injected params
+    (``context``), and any ``*args``/``**kwargs`` catch-alls.
+    """
+    hidden = (
+        _validation_injected_names(config) | {config.request_param_name} | _WORKER_INJECTED_PARAMS
+    )
+    variadic = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    return [
+        (name, param)
+        for name, param in config.func_params.items()
+        if name not in hidden and param.kind not in variadic
+    ]
+
+
 class WorkerCompat:
     """Make a validation wrapper look like the original handler to the worker.
 
     The Azure Functions worker (``index_function_app`` / ``loader.py``) inspects
     the registered callable to locate the HTTP trigger parameter and to build
     its annotation map.  Our wrapper uses a ``req`` positional plus a ``**_kw``
-    catch-all, which — if exposed verbatim — makes the worker either skip the
+    catch-all, which -- if exposed verbatim -- makes the worker either skip the
     handler or raise ``FunctionLoadError``.  This strategy object applies the
-    three compatibility shims that hide those internals.
+    compatibility shims that hide those internals while still exposing the
+    passthrough binding params the worker must bind (issue #297).
     """
 
     # See ._metadata_helpers.copy_identity_attrs for the rationale (no
     # __wrapped__, no __dict__ aliasing).  The attribute set is the canonical
     # SAFE_IDENTITY_ATTRS shared across the DX toolkit.
 
-    def apply(self, wrapper: Callable[..., Any], func: Callable[..., Any]) -> None:
+    def apply(
+        self,
+        wrapper: Callable[..., Any],
+        func: Callable[..., Any],
+        config: Any,
+    ) -> None:
         """Apply all worker-compatibility shims to *wrapper* in place."""
         self._copy_safe_metadata(wrapper, func)
-        self._override_signature(wrapper)
-        self._clear_annotations(wrapper)
+        passthrough = _passthrough_params(config)
+        annotations = self._resolve_passthrough_annotations(func, passthrough)
+        self._override_signature(wrapper, passthrough, annotations)
+        self._set_annotations(wrapper, annotations)
 
     def _copy_safe_metadata(self, wrapper: Callable[..., Any], func: Callable[..., Any]) -> None:
         """Copy safe identity attributes without setting ``__wrapped__``.
@@ -265,23 +329,68 @@ class WorkerCompat:
         """
         copy_identity_attrs(wrapper, func, SAFE_IDENTITY_ATTRS)
 
-    def _override_signature(self, wrapper: Callable[..., Any]) -> None:
-        """Expose only the single ``req`` parameter, hiding ``**_kw``.
+    def _resolve_passthrough_annotations(
+        self,
+        func: Callable[..., Any],
+        passthrough: list[tuple[str, inspect.Parameter]],
+    ) -> dict[str, Any]:
+        """Resolve passthrough param annotations to real type objects.
+
+        Handlers commonly use ``from __future__ import annotations`` (PEP 563),
+        so ``inspect.signature`` yields annotations as *strings*. The worker
+        resolves binding types via ``get_type_hints`` against the *handler's*
+        globals; our wrapper lives in this module with different globals, so a
+        raw string like ``"func.Out[str]"`` would fail to resolve. We therefore
+        resolve against ``func`` at decoration time and store the concrete type
+        objects, which need no further evaluation.
+        """
+        if not passthrough:
+            return {}
+        try:
+            hints = get_type_hints(func)
+        except Exception:  # pragma: no cover - defensive; user-module resolution
+            hints = {}
+        return {name: hints[name] for name, _param in passthrough if name in hints}
+
+    def _override_signature(
+        self,
+        wrapper: Callable[..., Any],
+        passthrough: list[tuple[str, inspect.Parameter]],
+        annotations: Mapping[str, Any],
+    ) -> None:
+        """Expose ``req`` plus any passthrough binding params, hiding ``**_kw``.
 
         Prevents ``FunctionLoadError: 'the following parameters are declared in
-        Python but not in the function definition: {'_kw'}'`` at load time.
+        Python but not in the function definition: {'_kw'}'`` at load time, while
+        still surfacing extra-binding params (``client``, ``order_doc``, ...) so
+        the worker can bind them by name (issue #297).
         """
-        _req_param = inspect.Parameter("req", inspect.Parameter.POSITIONAL_OR_KEYWORD)
-        setattr(wrapper, "__signature__", inspect.Signature([_req_param]))
+        params = [inspect.Parameter("req", inspect.Parameter.POSITIONAL_OR_KEYWORD)]
+        for name, param in passthrough:
+            params.append(
+                inspect.Parameter(
+                    name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=param.default,
+                    annotation=annotations.get(name, inspect.Parameter.empty),
+                )
+            )
+        setattr(wrapper, "__signature__", inspect.Signature(params))
 
-    def _clear_annotations(self, wrapper: Callable[..., Any]) -> None:
-        """Clear ``__annotations__`` so ``get_type_hints`` returns ``{}``.
+    def _set_annotations(
+        self,
+        wrapper: Callable[..., Any],
+        annotations: Mapping[str, Any],
+    ) -> None:
+        """Set ``__annotations__`` to only the passthrough binding types.
 
-        Otherwise the worker sees ``req: typing.Any`` and raises
-        ``FunctionLoadError: binding req has invalid non-type annotation``.
-        With no annotations it falls back to HttpRequest type inference.
+        ``req`` is intentionally left unannotated: with ``req: typing.Any`` the
+        worker raises ``binding req has invalid non-type annotation``; with no
+        annotation it falls back to ``HttpRequest`` type inference. Passthrough
+        binding params keep their (resolved) annotations so the worker can
+        validate output bindings such as ``func.Out[...]``.
         """
-        wrapper.__annotations__ = {}
+        wrapper.__annotations__ = dict(annotations)
 
 
 _WORKER_COMPAT = WorkerCompat()
@@ -332,7 +441,7 @@ def _make_wrapper(
 
         wrapper = _sync_wrapper
 
-    _WORKER_COMPAT.apply(wrapper, func)
+    _WORKER_COMPAT.apply(wrapper, func, config)
 
     # Expose validation metadata for external tool integration (e.g., OpenAPI bridge).
     # Uses the ecosystem-wide convention attribute so consumers never need to import

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -290,7 +290,6 @@ class TestLoggingDecoratorOrder:
             wrapped = validate_http(body=UserModel)(inner)
         assert wrapped is not inner
 
-
     def test_warns_preserves_logging_namespace(self) -> None:
         """The wrapper keeps the pre-existing ``logging`` namespace (merge, no clobber)."""
         from azure_functions_validation._metadata import METADATA_ATTR
@@ -305,9 +304,7 @@ class TestLoggingDecoratorOrder:
         assert "logging" in meta
         assert "validation" in meta
 
-    def test_no_warning_for_correct_order(
-        self, recwarn: pytest.WarningsRecorder
-    ) -> None:
+    def test_no_warning_for_correct_order(self, recwarn: pytest.WarningsRecorder) -> None:
         """Correct order: @validate_http runs first, sees no ``logging`` namespace."""
 
         def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
@@ -317,9 +314,7 @@ class TestLoggingDecoratorOrder:
         assert wrapped is not handler
         assert not any(issubclass(w.category, RuntimeWarning) for w in recwarn.list)
 
-    def test_no_warning_for_unrelated_namespace(
-        self, recwarn: pytest.WarningsRecorder
-    ) -> None:
+    def test_no_warning_for_unrelated_namespace(self, recwarn: pytest.WarningsRecorder) -> None:
         """A non-logging namespace (e.g. another sibling) must not trigger the warning."""
         from azure_functions_validation._metadata import METADATA_ATTR
 
@@ -330,7 +325,6 @@ class TestLoggingDecoratorOrder:
         wrapped = validate_http(body=UserModel)(handler)
         assert wrapped is not handler
         assert not any(issubclass(w.category, RuntimeWarning) for w in recwarn.list)
-
 
 
 # ---------------------------------------------------------------------------
@@ -387,9 +381,7 @@ class TestReqContextWorkerIndexing:
         seen: dict[str, object] = {}
 
         @validate_http(query=QueryModel)
-        async def handler(
-            req: HttpRequest, context: object, query: QueryModel
-        ) -> HttpResponse:
+        async def handler(req: HttpRequest, context: object, query: QueryModel) -> HttpResponse:
             seen["context"] = context
             return HttpResponse("ok")
 
@@ -402,3 +394,128 @@ class TestReqContextWorkerIndexing:
 
         assert response.status_code == 200
         assert seen["context"] is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Passthrough binding params: extra input/output bindings (issue #297)
+# ---------------------------------------------------------------------------
+
+
+class TestPassthroughBindingParams:
+    """Lock worker-compat behaviour for handlers that also declare an extra
+    input/output binding param alongside ``req`` (issue #297).
+
+    ``@validate_http`` must EXPOSE such binding params (e.g. a durable
+    ``client`` input or a ``func.Out[...]`` output) in the worker-visible
+    signature so the SDK can bind them by name, while still HIDING the
+    validation-injected params (``body``/``query``/...). Passthrough params must
+    also be forwarded to the raw handler at call time.
+    """
+
+    def test_output_binding_param_is_exposed_and_annotated(self) -> None:
+        import inspect
+
+        import azure.functions as func
+
+        @validate_http(body=UserModel)
+        def handler(req: HttpRequest, body: UserModel, order_doc: func.Out[str]) -> HttpResponse:
+            return HttpResponse("ok")
+
+        # req + passthrough output binding exposed; validation-injected body hidden.
+        assert list(inspect.signature(handler).parameters) == ["req", "order_doc"]
+        # Resolved (not string) annotation so the worker can validate func.Out[...].
+        assert handler.__annotations__ == {"order_doc": func.Out[str]}
+        assert not hasattr(handler, "__wrapped__")
+
+    def test_input_binding_param_is_exposed_and_forwarded(self) -> None:
+        import inspect
+
+        from azure_functions_validation.testing import MockHttpRequest
+
+        seen: dict[str, object] = {}
+
+        @validate_http(body=UserModel)
+        def handler(req: HttpRequest, client: object, body: UserModel) -> HttpResponse:
+            seen["client"] = client
+            seen["body"] = body
+            return HttpResponse("ok")
+
+        assert list(inspect.signature(handler).parameters) == ["req", "client"]
+
+        sentinel = object()
+        response = handler(MockHttpRequest(json={"name": "Alice", "age": 30}), client=sentinel)
+
+        assert response.status_code == 200
+        assert seen["client"] is sentinel
+        assert isinstance(seen["body"], UserModel)
+
+    @pytest.mark.anyio
+    async def test_async_output_binding_exposed_and_forwarded(self) -> None:
+        import inspect
+
+        import azure.functions as func
+
+        from azure_functions_validation.testing import MockHttpRequest
+
+        seen: dict[str, object] = {}
+
+        @validate_http(body=UserModel)
+        async def handler(
+            req: HttpRequest, order_doc: func.Out[str], body: UserModel
+        ) -> HttpResponse:
+            seen["order_doc"] = order_doc
+            seen["body"] = body
+            return HttpResponse("ok")
+
+        assert list(inspect.signature(handler).parameters) == ["req", "order_doc"]
+
+        out = _RecordingOut()
+        response = await handler(MockHttpRequest(json={"name": "Bob", "age": 22}), order_doc=out)
+
+        assert response.status_code == 200
+        assert seen["order_doc"] is out
+        assert isinstance(seen["body"], UserModel)
+
+    def test_context_stays_hidden_alongside_binding(self) -> None:
+        import inspect
+
+        import azure.functions as func
+
+        # ``context`` is worker-injected implicitly and must stay hidden (#284),
+        # while ``order_doc`` is a registered binding and must be exposed (#297).
+        @validate_http(query=QueryModel)
+        def handler(
+            req: HttpRequest,
+            context: object,
+            order_doc: func.Out[str],
+            query: QueryModel,
+        ) -> HttpResponse:
+            return HttpResponse("ok")
+
+        assert list(inspect.signature(handler).parameters) == ["req", "order_doc"]
+        assert "context" not in handler.__annotations__
+
+    def test_no_extra_binding_regression(self) -> None:
+        import inspect
+
+        # Plain handler: exposed signature stays a single ``req`` with no
+        # annotations, exactly as before (regression guard).
+        @validate_http(body=UserModel)
+        def handler(req: HttpRequest, body: UserModel) -> HttpResponse:
+            return HttpResponse("ok")
+
+        assert list(inspect.signature(handler).parameters) == ["req"]
+        assert handler.__annotations__ == {}
+
+
+class _RecordingOut:
+    """Minimal ``func.Out``-like stub for exercising output-binding forwarding."""
+
+    def __init__(self) -> None:
+        self._value: object = None
+
+    def set(self, value: object) -> None:
+        self._value = value
+
+    def get(self) -> object:
+        return self._value


### PR DESCRIPTION
## Summary
- `WorkerCompat` now exposes **passthrough binding params** (e.g. durable `@app.durable_client_input` `client`, `@app.cosmos_db_output` `order_doc`) in the wrapper's worker-visible `__signature__`/`__annotations__`, while still hiding validation-injected inputs (`body`/`query`/`path`/`headers`) and the implicitly worker-injected `context` param.
- Passthrough annotations are resolved via `get_type_hints` against the handler at decoration time, so PEP 563 string annotations like `"func.Out[str]"` become concrete types the worker can validate (the wrapper lives in a different module with different globals).
- Fixes the fundamental incompatibility where **no decorator ordering** let `@validate_http` work alongside an extra input/output binding.

## Acceptance (issue #297)
- [x] Exposes passthrough binding params; hides validation-injected params.
- [x] Forwards passthrough params to the raw handler at call time.
- [x] `@validate_http` innermost works with durable `client` input and `func.Out[...]` output.
- [x] Tests: durable input, sync + async output binding, `context`-stays-hidden (#284 guard), no-extra-binding regression.
- [x] Coverage 98.31% (>= 95%).
- [ ] Restore `@validate_http` in cookbook `async_http_polling` / `cqrs_read_projection` + bump lower bound — **follows once released**.

## Verification
- `make lint` (ruff + mypy) passes; full suite 98.31% coverage.
- Pre-existing unrelated failure: `test_version_matches_distribution_metadata` (stale editable-install metadata; fails on HEAD too).

Closes #297