### PR TITLE
fix(decorator): raise RuntimeError when @validate_http wraps a FunctionBuilder

### DIFF
--- a/.sisyphus/run-continuation/ses_0331fa056ffe4D3kPBmJU83aTK.json
+++ b/.sisyphus/run-continuation/ses_0331fa056ffe4D3kPBmJU83aTK.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_0331fa056ffe4D3kPBmJU83aTK",
+  "updatedAt": "2026-08-11T06:19:49.340Z",
+  "sources": {
+    "stop": {
+      "state": "idle",
+      "updatedAt": "2026-08-11T06:19:49.340Z"
+    }
+  }
+}

--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -77,15 +77,13 @@ def validate_http(
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         if _is_function_builder(func):
-            warnings.warn(
+            raise RuntimeError(
                 "@validate_http received an Azure Functions FunctionBuilder instead of "
-                "your handler, which means it was applied ABOVE @app.route. Validation "
-                "is NOT active for this function. Place @validate_http BELOW @app.route "
-                "so it wraps the handler directly.",
-                RuntimeWarning,
-                stacklevel=2,
+                "your handler, which means it was applied ABOVE a binding decorator "
+                "(e.g. @app.route). Validation is NOT active in this order and no "
+                "endpoint metadata is emitted. Place @validate_http BELOW the binding "
+                "decorator (innermost) so it wraps the handler directly."
             )
-            return func
 
         # Cross-repo decorator-order guard (azure-functions-logging#310).
         if _has_logging_metadata(func):

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -206,9 +206,9 @@ class TestCopyIdentityAttrs:
 
 
 class TestWrongDecoratorOrder:
-    """@validate_http applied above @app.route must warn, not silently no-op."""
+    """@validate_http applied above @app.route must raise, not silently no-op."""
 
-    def test_real_sdk_function_builder_warns_and_returns_unwrapped(self) -> None:
+    def test_real_sdk_function_builder_raises_and_does_not_wrap(self) -> None:
         """A genuine SDK ``FunctionBuilder`` (from ``@app.route``) must be detected.
 
         Uses the real ``azure.functions`` SDK so this test fails automatically if a
@@ -227,20 +227,18 @@ class TestWrongDecoratorOrder:
         builder = app.route(route="users", methods=["POST"])(handler)
         assert isinstance(builder, FunctionBuilder)
 
-        with pytest.warns(RuntimeWarning, match=r"@app\.route"):
-            result = validate_http(body=UserModel)(builder)
-        assert result is builder
+        with pytest.raises(RuntimeError, match=r"@app\.route"):
+            validate_http(body=UserModel)(builder)
 
-    def test_function_builder_by_type_name_fallback_warns(self) -> None:
+    def test_function_builder_by_type_name_fallback_raises(self) -> None:
         """SDK builds without the method are still caught by the type-name fallback."""
 
         class FunctionBuilder:  # name is the fallback signal
             pass
 
         builder = FunctionBuilder()
-        with pytest.warns(RuntimeWarning, match="FunctionBuilder"):
-            result = validate_http(body=UserModel)(builder)
-        assert result is builder
+        with pytest.raises(RuntimeError, match="FunctionBuilder"):
+            validate_http(body=UserModel)(builder)
 
     def test_normal_handler_is_not_flagged(self, recwarn: pytest.WarningsRecorder) -> None:
         """A normal handler must wrap without emitting the wrong-order warning."""


### PR DESCRIPTION
## Summary
- Escalate the FunctionBuilder branch in `validate_http` from a silent `RuntimeWarning` + `return func` no-op to a fail-fast `RuntimeError`.
- When `@validate_http` is applied ABOVE a binding decorator (`@app.route`, `@app.durable_client_input`, `@app.cosmos_db_output`, ...) it receives an SDK `FunctionBuilder`, so validation was silently inactive and no endpoint metadata was emitted while the app booted normally. This now hard-fails at indexing/import time.
- The separate `@with_context` (azure-functions-logging) order guard stays a `RuntimeWarning` because validation still runs in that order.

## Rationale
For a validation library, fail-open validation bypass is worse than a loud failure. In 0.x, the broken decorator order was already non-functional. Oracle-reviewed design decision.

## Tests
- Updated the two FunctionBuilder tests to assert `pytest.raises(RuntimeError)`.
- `make test` (311 passed, 6 skipped, 98.31% coverage), `make lint`, `make typecheck` all green.

## Breaking change note
This can fail the whole app indexing rather than one endpoint — intentional, since the current config produces no validation and no metadata.