### PR TITLE
chore: bump ruff to 0.16.2 and repair pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.16.2
     hooks:
       - id: ruff-format
       - id: ruff
@@ -24,6 +27,7 @@ repos:
     rev: 1.9.4
     hooks:
       - id: bandit
+        language_version: python3.12
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
         files: "^src/"
@@ -32,7 +36,7 @@ repos:
     hooks:
       - id: forbid-korean
         name: Forbid Korean Characters
-        entry: bash -c 'if grep -RIl --exclude-dir=.venv --exclude-dir=.git -n "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null; then echo "Korean characters detected. Please use English only."; exit 1; fi'
+        entry: bash -c 'if grep -RIn --exclude-dir=.venv --exclude-dir=.git "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null | grep -vE "README\.(ko|ja|zh-CN)\.md"; then echo "Korean characters detected. Please use English only."; exit 1; fi'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/examples/async_validation/function_app.py
+++ b/examples/async_validation/function_app.py
@@ -26,4 +26,3 @@ async def async_validation(
 ) -> AsyncGreetingResponse:
     await asyncio.sleep(0)
     return AsyncGreetingResponse(message=f"Hello {body.name}")
-

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -1,9 +1,11 @@
 """E2E test function app for azure-functions-validation."""
+
 import json
 import logging
 
-from pydantic import BaseModel, Field
 import azure.functions as func
+from pydantic import BaseModel, Field
+
 from azure_functions_validation import validate_http
 
 app = func.FunctionApp()

--- a/examples/profile_validation/function_app.py
+++ b/examples/profile_validation/function_app.py
@@ -47,4 +47,3 @@ def get_profile(
         view=view,
         request_id=headers.x_request_id,
     )
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
     "pytest",
     "pytest-anyio",
     "pytest-cov",
-    "ruff==0.16.1",
+    "ruff==0.16.2",
     "jsonschema",
     "requests",
     "types-requests",


### PR DESCRIPTION
## Summary
- Bump pinned `ruff` dev dependency **0.16.1 → 0.16.2** and apply the resulting formatter changes.
- Bump `ruff-pre-commit` rev **v0.15.6 → v0.16.2** so the hook formats identically to the pinned tool.
- Repair pre-commit env: pin the `bandit` hook (and default python-language version) to **python3.12** — the default env was resolving to system Python 3.9.6, which modern bandit rejects (`requires >=3.10`), crashing every commit.
- Narrow the `forbid-korean` hook so the README language-selector nav links no longer trip the Hangul check (it previously failed on `main`).

## Verification
- `pre-commit run --all-files` → ruff-format, ruff, mypy, bandit, forbid-korean all **Passed**.

## Scope
- Dev tooling + pre-commit config only. No runtime dependency or logic changes.
- `mypy`/`bandit` version pins left untouched (already at/above the highest versions on the active package index).