### PR TITLE
ci: gate PyPI publish on library + cookbook verification

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,13 +14,19 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
+# Verify-before-publish gate (see docs/RELEASE.md / AGENTS.md):
+#   build -> lib-tests -> cookbook-smoke (against the built wheel) -> publish
+# The publish job uploads the EXACT artifact that was tested; it never rebuilds.
+# A tag whose gate fails is a failed release candidate: the version stays
+# unpublished. Recover by fixing forward and cutting the next patch tag
+# (never move a tag that may already have been consumed).
 jobs:
-  build-and-publish:
+  build:
+    name: Build & verify version
     runs-on: ubuntu-latest
-    environment: pypi
-
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -38,6 +44,7 @@ jobs:
           pip install build
 
       - name: Check if tag matches __version__
+        id: version
         run: |
           TAG_NAME="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           VERSION_FROM_FILE=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_validation/__init__.py)
@@ -49,9 +56,100 @@ jobs:
             echo "::error ::Version in __init__.py ($VERSION_FROM_FILE) does not match git tag ($TAG_VERSION)"
             exit 1
           fi
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build distribution packages
         run: python -m build
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 5
+
+  lib-tests:
+    name: Library tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Run test suite
+        run: hatch run test
+
+  cookbook-smoke:
+    name: Cookbook dogfood smoke (candidate wheel)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cookbook (downstream consumer)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          repository: yeongseon/azure-functions-cookbook-python
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Download candidate wheel
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: candidate-dist
+
+      - name: Install cookbook environment
+        run: |
+          pip install hatch
+          make install
+
+      - name: Install candidate wheel over the PyPI floor
+        run: |
+          WHEEL=$(ls candidate-dist/*.whl | head -n1)
+          echo "Installing candidate wheel: $WHEEL"
+          hatch run pip install --force-reinstall --no-deps "$WHEEL"
+
+      - name: Verify candidate version is under test
+        run: |
+          EXPECTED="${{ needs.build.outputs.version }}"
+          ACTUAL=$(hatch run python -c "import importlib.metadata as m; print(m.version('azure-functions-validation'))")
+          echo "Expected candidate version: $EXPECTED"
+          echo "Installed version:          $ACTUAL"
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error ::Cookbook is not exercising the candidate wheel ($ACTUAL != $EXPECTED)"
+            exit 1
+          fi
+
+      - name: Run cookbook smoke tests against candidate
+        run: hatch run smoke
+
+  publish:
+    name: Publish to PyPI
+    needs: [build, lib-tests, cookbook-smoke]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download tested distribution artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ examples/e2e_app/.python_packages/
 
 # Sisyphus/OMC internal orchestration state
 .sisyphus/
+.omc/
+.claude/
+*.agent-session.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,13 +91,14 @@ When splitting a large piece of work into focused issues, keep the umbrella open
 ### Flow
 1. `make release-patch` (or `-minor` / `-major`) on `main`
 2. This runs: `hatch version` → `git commit` → `make changelog` → `git commit` → `git tag` → `git push`
-3. Tag push triggers **Publish to PyPI** GitHub Actions workflow automatically.
+3. Tag push triggers the **Publish to PyPI** GitHub Actions workflow. **Verification is a pre-publish gate, not a post-publish check.** The workflow runs `build → lib-tests → cookbook-smoke → publish`; the `publish` job only runs after the candidate wheel passes the library test suite AND the downstream cookbook smoke tests, and it uploads the exact artifact that was tested (it never rebuilds). A 0.21.0-class regression therefore cannot reach PyPI — a failed gate leaves the version unpublished.
 4. Update `docs/changelog.md` separately if needed (different format from `CHANGELOG.md`).
-5. **Verify the release against the dogfood cookbook.** Once **Publish to PyPI** succeeds, confirm the downstream consumer still passes on the freshly published version:
-   - In [`azure-functions-cookbook-python`](https://github.com/yeongseon/azure-functions-cookbook-python), upgrade to the new release (`hatch run pip install -U "azure-functions-validation>=X.Y,<1"`) and run `make test`.
-   - Treat any new `RuntimeWarning`/`DeprecationWarning` from `@validate_http` as a release-blocking signal — the library surfaces decorator-order and API-drift problems as warnings, so a clean run (zero validation warnings) is part of the release gate.
-   - If the cookbook pins a lower bound (`azure-functions-validation>=X.Y,<1`), bump it to the new minor in the same verification PR so examples are tested against the version they advertise.
-   - A release is **not** considered done until the cookbook passes on the published version.
+5. **Failed-gate recovery (stuck tag).** A git tag is immutable and may already have been consumed, so if the gate fails do **not** move or reuse the tag. Fix forward on `main` and cut the next patch tag (`make release-patch`). The unpublished version number is simply skipped.
+6. **Local pre-tag dry run (recommended before releasing).** Reproduce the automated gate locally before pushing the tag so failures surface before a version is burned:
+   - Build the candidate: `make build` (produces `dist/*.whl`).
+   - In [`azure-functions-cookbook-python`](https://github.com/yeongseon/azure-functions-cookbook-python): `make install`, then install the candidate over the PyPI floor with `hatch run pip install --force-reinstall --no-deps <path-to-candidate-wheel>`, confirm `importlib.metadata.version("azure-functions-validation")` equals the tag, and run `hatch run smoke`.
+   - Treat any new `RuntimeWarning`/`DeprecationWarning` from `@validate_http` as release-blocking — the library surfaces decorator-order and API-drift problems as warnings, so a clean run (zero validation warnings) is part of the gate.
+   - If the cookbook pins a lower bound (`azure-functions-validation>=X.Y,<1`), bump it to the new minor in the same release PR so examples are tested against the version they advertise.
 
 ## Golden Commands
 


### PR DESCRIPTION
## Context
Process-review follow-up (point 1: *verify before publish*). Today `publish-pypi.yml` is fire-and-forget: on tag push it does `check version → build → upload to PyPI` with **no test gate**. The 0.21.0 incident is the direct consequence — a regression that the library's own tests did not catch was only found by the cookbook **after** publish, leaving a broken version live on PyPI for ~a day. AGENTS.md even documented cookbook verification as a step that runs *after* "Publish to PyPI succeeds."

This reverses the order so verification **gates** the upload.

## Design (reviewed with Oracle)
Build once → test that exact artifact → publish the same artifact:

```
build ──▶ lib-tests ──┐
     └──▶ cookbook-smoke ──▶ publish   (publish: needs [build, lib-tests, cookbook-smoke])
```

- **build** — verify tag == `__version__`, `python -m build`, upload `dist/` as an artifact (exposes `version` output).
- **lib-tests** — run the library test suite (`hatch run test`).
- **cookbook-smoke** — checkout `azure-functions-cookbook-python`, `make install` (siblings from PyPI), then **install the candidate wheel by path** (`--force-reinstall --no-deps`) so it overrides the `>=X.Y,<1` floor, **assert `importlib.metadata.version` == tag** (guarantees the candidate — not a PyPI copy — is under test), then run `hatch run smoke` (fast module-import gate across all 80 recipes).
- **publish** — downloads the **already-tested** `dist/` artifact and uploads it via `pypa/gh-action-pypi-publish` (Trusted Publishing / OIDC, `environment: pypi`). **Never rebuilds.**

Why not TestPyPI: adds a separate project/OIDC env + immutable-version friction for no extra confidence over artifact-based install (Oracle concurred).

## Docs
- **AGENTS.md** Flow rewritten: verification is now a **pre-publish gate**, with:
  - **Failed-gate / stuck-tag recovery** — a failed gate leaves the version unpublished; fix forward and cut the next patch tag (never move a consumed tag).
  - A **local pre-tag dry run** that reproduces the gate (`make build` → install candidate wheel into cookbook → verify version → `hatch run smoke`) so failures surface before a version is burned.

## Also (cheap fix, point 3)
- `.gitignore`: harden agent-state ignores (`.omc/`, `.claude/`, `*.agent-session.json`) alongside the existing `.sisyphus/`. (This repo already stopped tracking the leaked `.sisyphus/run-continuation/*.json` in `ac58015`; this prevents recurrence of the whole class.)

## Acceptance Checklist
- [x] `publish` depends on `build`, `lib-tests`, `cookbook-smoke`
- [x] Published artifact is the exact tested artifact (no rebuild in publish)
- [x] Candidate version asserted before cookbook smoke runs
- [x] YAML validated; action pins reuse known-good SHAs already in the repo
- [ ] First real tag release exercises the full gate end-to-end

## Scope / follow-ups
- **Pilot on validation only.** Once proven on a real release, template to the other 7 libraries (ideally a `workflow_call` reusable workflow in the org `.github` repo to avoid 8-way drift).
- Point 2 (automated sibling floor bumps) and cross-repo `.gitignore` propagation tracked separately.