### PR TITLE
ci: gate publish on local func-host e2e + real-Azure certification

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -1,10 +1,21 @@
-name: e2e-azure
+name: Azure Release Certification
 
+# Deploys the candidate to REAL Azure, runs live e2e, and (on success) records a
+# certification artifact keyed by commit SHA + version. publish-pypi.yml's
+# verify-azure-certification gate requires a fresh, matching certification before
+# any PyPI upload. This is a per-release certification, not a per-publish job:
+# it no longer triggers on tag push (that raced publish and could not gate it).
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch/tag/SHA) of the release commit to certify
+        required: false
+        type: string
+      version:
+        description: Expected package version (must match source __version__)
+        required: false
+        type: string
 
 permissions:
   id-token: write
@@ -32,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Compute resource names
         id: names
@@ -190,6 +203,39 @@ jobs:
         run: pytest tests/e2e -v --no-cov --html=e2e-report/report.html --self-contained-html
         env:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+
+      - name: Record certification
+        run: |
+          SHA=$(git rev-parse HEAD)
+          FILE_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_validation/__init__.py)
+          REQ_VERSION="${{ inputs.version }}"
+          if [ -n "$REQ_VERSION" ] && [ "$REQ_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error ::Requested certification version ($REQ_VERSION) != source version ($FILE_VERSION)"
+            exit 1
+          fi
+          VERSION="${REQ_VERSION:-$FILE_VERSION}"
+          mkdir -p cert
+          cat > cert/certification.json <<EOF
+          {
+            "package": "azure-functions-validation",
+            "version": "$VERSION",
+            "commit": "$SHA",
+            "ref": "${{ inputs.ref || github.ref }}",
+            "workflow": "e2e-azure.yml",
+            "run_id": "${{ github.run_id }}",
+            "result": "success",
+            "certified_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat cert/certification.json
+
+      - name: Upload certification record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: azure-cert
+          path: cert/
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload e2e report
         if: always()

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -16,7 +16,16 @@ permissions:
   contents: read
 
 # Verify-before-publish gate (see docs/RELEASE.md / AGENTS.md):
-#   build -> lib-tests -> cookbook-smoke (against the built wheel) -> publish
+#   build -> lib-tests -> cookbook-smoke -> cookbook-local-e2e
+#         -> verify-azure-certification -> publish
+# Tiered runtime verification before any PyPI upload:
+#   * lib-tests            : the library's own unit suite (against the built wheel).
+#   * cookbook-smoke       : downstream module-import checks (catches registration/import drift).
+#   * cookbook-local-e2e   : real func host + Azurite, live HTTP invocation of the candidate
+#                            (catches 'imports fine but runtime breaks' regressions, no cloud).
+#   * verify-azure-certification : requires the EXACT release commit to have passed a real-Azure
+#                            deploy+live-e2e certification (e2e-azure.yml) that is fresh and
+#                            version/SHA-matched. Real Azure is certified per release, not per publish.
 # The publish job uploads the EXACT artifact that was tested; it never rebuilds.
 # A tag whose gate fails is a failed release candidate: the version stays
 # unpublished. Recover by fixing forward and cutting the next patch tag
@@ -137,9 +146,149 @@ jobs:
       - name: Run cookbook smoke tests against candidate
         run: hatch run smoke
 
+  cookbook-local-e2e:
+    name: Cookbook local runtime e2e (func + Azurite, candidate wheel)
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      # Pin Core Tools; bump only after a verified run. npm is Microsoft's
+      # documented v4 install path (see e2e-azure.yml for rationale).
+      FUNCTIONS_CORE_TOOLS_VERSION: "4.12.0"
+    steps:
+      - name: Checkout cookbook (downstream consumer)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          repository: yeongseon/azure-functions-cookbook-python
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Set up Node.js (func Core Tools + Azurite)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Install Azure Functions Core Tools + Azurite
+        run: |
+          npm install -g "azure-functions-core-tools@${FUNCTIONS_CORE_TOOLS_VERSION}" azurite
+          func --version
+          azurite --version
+
+      - name: Download candidate wheel
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: candidate-dist
+
+      - name: Install cookbook environment
+        run: |
+          pip install hatch
+          make install
+
+      - name: Install candidate wheel over the PyPI floor
+        run: |
+          WHEEL=$(ls candidate-dist/*.whl | head -n1)
+          echo "Installing candidate wheel: $WHEEL"
+          hatch run pip install --force-reinstall --no-deps "$WHEEL"
+
+      - name: Verify candidate version is under test
+        run: |
+          EXPECTED="${{ needs.build.outputs.version }}"
+          ACTUAL=$(hatch run python -c "import importlib.metadata as m; print(m.version('azure-functions-validation'))")
+          echo "Expected candidate version: $EXPECTED"
+          echo "Installed version:          $ACTUAL"
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error ::Cookbook is not exercising the candidate wheel ($ACTUAL != $EXPECTED)"
+            exit 1
+          fi
+
+      - name: Run cookbook HTTP e2e against candidate (real func host)
+        run: hatch run e2e tests/e2e/test_http_examples.py
+        timeout-minutes: 15
+
+  verify-azure-certification:
+    name: Verify Azure release certification
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Resolve release commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Locate successful Azure certification for this commit
+        id: cert
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          COMMIT: ${{ steps.commit.outputs.sha }}
+        run: |
+          # A release may only publish if the EXACT commit was certified against
+          # real Azure by the trusted certification workflow (see e2e-azure.yml).
+          RUN_ID=$(gh run list \
+            --workflow e2e-azure.yml \
+            --json databaseId,headSha,conclusion \
+            --limit 50 \
+            --jq "[.[] | select(.headSha==\"$COMMIT\" and .conclusion==\"success\")] | first | .databaseId")
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::error ::No successful Azure certification run found for commit $COMMIT. Dispatch the 'Azure Release Certification' (e2e-azure.yml) workflow on this release commit before publishing."
+            exit 1
+          fi
+          echo "Found certification run: $RUN_ID"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download certification record
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: azure-cert
+          path: cert
+          run-id: ${{ steps.cert.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Assert certification matches this release
+        env:
+          COMMIT: ${{ steps.commit.outputs.sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+          FRESHNESS_DAYS: "14"
+        run: |
+          python3 - "$COMMIT" "$VERSION" "$FRESHNESS_DAYS" <<'PY'
+          import json, sys, datetime, pathlib
+          commit, version, fresh_days = sys.argv[1], sys.argv[2], int(sys.argv[3])
+          cert = json.loads(pathlib.Path("cert/certification.json").read_text())
+          def fail(m):
+              print(f"::error ::{m}")
+              sys.exit(1)
+          if cert.get("result") != "success":
+              fail("certification result is not success")
+          if cert.get("package") != "azure-functions-validation":
+              fail(f"cert package {cert.get('package')} != azure-functions-validation")
+          if cert.get("commit") != commit:
+              fail(f"cert commit {cert.get('commit')} != release commit {commit}")
+          if cert.get("version") != version:
+              fail(f"cert version {cert.get('version')} != release version {version}")
+          ts = cert.get("certified_at")
+          if not ts:
+              fail("cert missing certified_at")
+          certified = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+          age = datetime.datetime.now(datetime.timezone.utc) - certified
+          if age > datetime.timedelta(days=fresh_days):
+              fail(f"certification is stale: {age.days}d > {fresh_days}d")
+          print(f"Azure certification verified: {version}@{commit[:12]} certified {age.days}d ago")
+          PY
+
   publish:
     name: Publish to PyPI
-    needs: [build, lib-tests, cookbook-smoke]
+    needs: [build, lib-tests, cookbook-smoke, cookbook-local-e2e, verify-azure-certification]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,17 +88,34 @@ When splitting a large piece of work into focused issues, keep the umbrella open
 - `make release VERSION=x.y.z` — set explicit version, update changelog, tag, and push
 - `make tag-release VERSION=x.y.z` — create and push an annotated tag (used internally by release targets)
 
+### Tiered runtime verification (what gates a release)
+
+Release verification is layered; each tier catches a different failure class, and **every tier is a pre-publish gate** (not a post-publish check):
+
+| Tier | Runs where | Catches |
+| --- | --- | --- |
+| `lib-tests` | publish-pypi.yml (per publish) | library unit regressions |
+| `cookbook-smoke` | publish-pypi.yml (per publish) | downstream import/registration drift (0.21.0 class) |
+| `cookbook-local-e2e` | publish-pypi.yml (per publish) | "imports fine but runtime breaks" — real `func` host + Azurite, live HTTP invocation of the candidate wheel, no cloud |
+| `verify-azure-certification` | publish-pypi.yml (per publish) | requires a fresh, SHA+version-matched **real-Azure** certification for the exact release commit |
+| Azure Release Certification (`e2e-azure.yml`) | `workflow_dispatch`, per release | cloud-only drift — deploys to real Azure, runs live e2e, records a certification artifact. **Certified per release, not per publish** (it no longer triggers on tag, which used to race the publish and could not gate it). |
+
 ### Flow
 1. `make release-patch` (or `-minor` / `-major`) on `main`
 2. This runs: `hatch version` → `git commit` → `make changelog` → `git commit` → `git tag` → `git push`
-3. Tag push triggers the **Publish to PyPI** GitHub Actions workflow. **Verification is a pre-publish gate, not a post-publish check.** The workflow runs `build → lib-tests → cookbook-smoke → publish`; the `publish` job only runs after the candidate wheel passes the library test suite AND the downstream cookbook smoke tests, and it uploads the exact artifact that was tested (it never rebuilds). A 0.21.0-class regression therefore cannot reach PyPI — a failed gate leaves the version unpublished.
+3. Tag push triggers the **Publish to PyPI** GitHub Actions workflow. **Verification is a pre-publish gate, not a post-publish check.** The `publish` job runs only after `build → lib-tests → cookbook-smoke → cookbook-local-e2e → verify-azure-certification` all pass, and it uploads the exact artifact that was tested (it never rebuilds). Because `cookbook-local-e2e` exercises the candidate against a real Functions host and `verify-azure-certification` requires a matching real-Azure certification, a 0.21.0-class regression (import-clean but runtime-broken) cannot reach PyPI — a failed gate leaves the version unpublished.
 4. Update `docs/changelog.md` separately if needed (different format from `CHANGELOG.md`).
 5. **Failed-gate recovery (stuck tag).** A git tag is immutable and may already have been consumed, so if the gate fails do **not** move or reuse the tag. Fix forward on `main` and cut the next patch tag (`make release-patch`). The unpublished version number is simply skipped.
 6. **Local pre-tag dry run (recommended before releasing).** Reproduce the automated gate locally before pushing the tag so failures surface before a version is burned:
    - Build the candidate: `make build` (produces `dist/*.whl`).
    - In [`azure-functions-cookbook-python`](https://github.com/yeongseon/azure-functions-cookbook-python): `make install`, then install the candidate over the PyPI floor with `hatch run pip install --force-reinstall --no-deps <path-to-candidate-wheel>`, confirm `importlib.metadata.version("azure-functions-validation")` equals the tag, and run `hatch run smoke`.
+   - Reproduce the local func-host tier: in the cookbook, with the candidate wheel installed, run `hatch run e2e tests/e2e/test_http_examples.py` (starts a real `func` host + Azurite and invokes the HTTP examples that exercise `@validate_http`). This is the local stand-in for `cookbook-local-e2e` and must pass before tagging.
    - Treat any new `RuntimeWarning`/`DeprecationWarning` from `@validate_http` as release-blocking — the library surfaces decorator-order and API-drift problems as warnings, so a clean run (zero validation warnings) is part of the gate.
    - If the cookbook pins a lower bound (`azure-functions-validation>=X.Y,<1`), bump it to the new minor in the same release PR so examples are tested against the version they advertise.
+7. **Real-Azure certification (required once per release, before the final tag).** `cookbook-local-e2e` substitutes for Azure on every publish, but a release must still be certified against real Azure at least once. Before pushing the release tag, dispatch the **Azure Release Certification** workflow on the exact release commit and version:
+   - `gh workflow run e2e-azure.yml --ref main -f ref=<release-sha> -f version=<x.y.z>`
+   - The run deploys to real Azure, executes the live e2e suite, and uploads the `azure-cert` artifact (keyed by commit SHA + version).
+   - `verify-azure-certification` in `publish-pypi.yml` later requires a successful, SHA+version-matched, non-stale (<14 day) certification for the release commit; without it the publish gate fails and the version stays unpublished.
 
 ## Golden Commands
 


### PR DESCRIPTION
## Context
Follow-up to #301. The base gate verifies library + cookbook **import** smoke before publish, but that cannot catch a runtime regression that imports cleanly yet breaks when actually served (the 0.21.0 failure class). It also left the real-Azure `e2e-azure.yml` triggered on `push: tags` — the same trigger as publish — so the two ran in parallel with no dependency and PyPI publish finished before real-Azure e2e completed, i.e. Azure verification could never gate a release.

## What changed
- **`publish-pypi.yml`** — `publish` now additionally needs two blocking jobs:
  - **`cookbook-local-e2e`** — installs func Core Tools 4.12.0 + Azurite, installs the candidate wheel over the PyPI floor (`--force-reinstall --no-deps`), version-asserts, and runs the cookbook HTTP examples against a **real func host** (`hatch run e2e tests/e2e/test_http_examples.py`).
  - **`verify-azure-certification`** — resolves the release commit and requires a successful, **SHA + version matched, non-stale (<14 day)** real-Azure certification (`azure-cert` artifact) for that exact commit; otherwise the publish gate fails and the version stays unpublished.
- **`e2e-azure.yml`** — renamed to *Azure Release Certification*; **removed the `push: tags` trigger** (killed the race), made it `workflow_dispatch`-only with `ref` + `version` inputs, and added steps that record + upload the `azure-cert` certification artifact keyed by commit SHA + version.
- **`AGENTS.md`** — documents the tiered verification model (5 tiers) and updates the release flow with the local func-host dry-run and the pre-tag real-Azure certification dispatch.

## Verification
- Both workflows YAML-parse; job graph confirmed (`publish.needs` = all 5 tiers; `e2e-azure` is dispatch-only).
- Local dry-run of the new local-e2e tier passed: real func hosts + Azurite, 23 tests (17 exercising `@validate_http`) against the candidate wheel.

## Note
The new gate jobs are tag-triggered, so (like #301) they do not execute on this PR itself; they first run on the next release tag. Real-Azure certification is dispatched per release before the final tag.

## Out of scope
- Rolling the reusable-workflow/composite-action version out to the 7 sibling repos (tracked separately).