### PR TITLE
docs: sync docs with deprecated request_model and public adapter exports

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5,16 +5,20 @@ This page documents the public API exported from `azure_functions_validation`.
 ```python
 from azure_functions_validation import (
     ErrorFormatter,
+    HttpError,
+    PydanticAdapter,
     ResponseValidationError,
     SerializationError,
+    ValidationAdapter,
     validate_http,
 )
 ```
 
 !!! note "Public surface"
-    The package exports: `validate_http`, `ResponseValidationError`,
-    `ErrorFormatter`, and `SerializationError`. Pipeline and adapter internals
-    are not public contracts.
+    The package exports (`__all__`): `validate_http`, `ResponseValidationError`,
+    `SerializationError`, `ErrorFormatter`, `ValidationAdapter`, `PydanticAdapter`,
+    and `HttpError`. Pipeline internals (`PipelineConfig`, `run_pipeline`) are not
+    public contracts.
 
 ## `validate_http`
 
@@ -137,7 +141,13 @@ def get_user(
     }
 ```
 
-### Usage example: custom `request_model` shorthand
+### Usage example: `request_model` shorthand (deprecated)
+
+!!! warning "Deprecated"
+    `request_model` is a deprecated alias for `body` and emits a
+    `DeprecationWarning`. Use `body=` instead; it injects a parameter named
+    `body` (rather than `req_model`). `request_model` will be removed in a
+    future release. See the migration below.
 
 ```python
 import azure.functions as func
@@ -155,10 +165,14 @@ app = func.FunctionApp()
 
 @app.function_name(name="create_task")
 @app.route(route="tasks", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
-@validate_http(request_model=CreateTaskRequest)
-def create_task(req: func.HttpRequest, req_model: CreateTaskRequest) -> dict[str, str]:
-    return {"title": req_model.title}
+@validate_http(body=CreateTaskRequest)
+def create_task(req: func.HttpRequest, body: CreateTaskRequest) -> dict[str, str]:
+    return {"title": body.title}
 ```
+
+!!! note "Migrating from `request_model`"
+    Replace `@validate_http(request_model=Model)` (injects `req_model`) with
+    `@validate_http(body=Model)` (injects `body`).
 
 !!! warning "Conflict rule"
     `request_model` cannot be combined with `body`, `query`, `path`, or `headers`.
@@ -314,16 +328,6 @@ misparsing new fields.
 - A **custom** `ErrorFormatter` owns its output shape entirely: the marker is
   never injected into a successful custom formatter's response. Emit your own
   version field there if you need one.
-{
-  "detail": [
-    {
-      "loc": ["body", "field_name"],
-      "msg": "Field required",
-      "type": "missing"
-    }
-  ]
-}
-```
 
 Common status codes:
 
@@ -343,14 +347,29 @@ Common status codes:
     added to disambiguate same-named fields across inputs. To keep the previous
     unprefixed `loc` for one migration cycle, pass `legacy_loc=True` to
     `validate_http`. This escape hatch will be removed in a future release.
-    - response errors: `loc` equals `["response"]`
+
+## Custom adapters
+
+`ValidationAdapter` (the adapter protocol) and `PydanticAdapter` (the default
+implementation) are part of the public API. Pass a custom `adapter=` to
+`validate_http` to plug in a non-Pydantic validation backend; most deployments
+should keep the default `PydanticAdapter`.
+
+```python
+from azure_functions_validation import PydanticAdapter, ValidationAdapter, validate_http
+
+adapter: ValidationAdapter = PydanticAdapter(legacy_loc=False)
+
+
+@validate_http(body=RequestModel, adapter=adapter)
+def handler(req, body): ...
+```
 
 ## Internal references
 
 These modules are useful for advanced extension work but are internal APIs:
 
 - `pipeline.py`: `PipelineConfig`, `run_pipeline`, `run_pipeline_async`
-- `adapter.py`: `ValidationAdapter`, `PydanticAdapter`
 
 For full implementation patterns, see [Usage](usage.md) and
 [Architecture](architecture.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,9 +153,13 @@ Exported symbols (via `__all__`):
 - `ResponseValidationError` — exception type for response model validation failures
 - `SerializationError` — exception type for response serialization failures
 - `ErrorFormatter` — type alias for custom error formatting callables
+- `HttpError` — raise from a handler to return a controlled error envelope
+- `ValidationAdapter` — the adapter protocol (public extension point)
+- `PydanticAdapter` — the default Pydantic v2 adapter implementation
 - `__version__` — package version string
 
-Everything else (`PipelineConfig`, `PydanticAdapter`, `ValidationAdapter` protocol, internal pipeline functions) is not part of the top-level public API.
+Everything else (`PipelineConfig`, internal pipeline functions) is not part of
+the top-level public API.
 
 ## Key Design Decisions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,12 @@ def inspect(req: func.HttpRequest, headers: HeadersModel) -> dict[str, str]:
     return {"request_id": headers.x_request_id}
 ```
 
-### `request_model`
+### `request_model` (deprecated)
+
+!!! warning "Deprecated — use `body`"
+    `request_model` is a deprecated alias for `body` and emits a
+    `DeprecationWarning`. Prefer `body=` (which injects a parameter named
+    `body`). `request_model` will be removed in a future release.
 
 `request_model` is shorthand for body validation and injects a parameter named
 `req_model`.
@@ -109,9 +114,16 @@ class RequestModel(BaseModel):
     text: str
 
 
+# Deprecated form (emits DeprecationWarning):
 @validate_http(request_model=RequestModel)
 def post(req: func.HttpRequest, req_model: RequestModel) -> dict[str, str]:
     return {"text": req_model.text}
+
+
+# Preferred form:
+@validate_http(body=RequestModel)
+def post_preferred(req: func.HttpRequest, body: RequestModel) -> dict[str, str]:
+    return {"text": body.text}
 ```
 
 !!! warning "Mutual exclusivity"

--- a/docs/examples/crud_api.md
+++ b/docs/examples/crud_api.md
@@ -28,7 +28,7 @@ request and response contracts.
 | --- | --- | --- |
 | `GET` | `/api/tasks` | List tasks with optional query filters |
 | `GET` | `/api/tasks/{task_id}` | Get one task by id |
-| `POST` | `/api/tasks` | Create task with `request_model` shorthand |
+| `POST` | `/api/tasks` | Create task with `body` validation |
 | `PATCH` | `/api/tasks/{task_id}` | Partial update with body + path validation |
 | `DELETE` | `/api/tasks/{task_id}` | Delete task and return `204 No Content` |
 
@@ -114,15 +114,15 @@ def get_task(req: func.HttpRequest, path: TaskPath) -> dict[str, object]:
 
 @app.function_name(name="create_task")
 @app.route(route="tasks", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
-@validate_http(request_model=TaskCreateRequest, response_model=TaskResponse)
-def create_task(req: func.HttpRequest, req_model: TaskCreateRequest) -> TaskResponse:
+@validate_http(body=TaskCreateRequest, response_model=TaskResponse)
+def create_task(req: func.HttpRequest, body: TaskCreateRequest) -> TaskResponse:
     global _NEXT_ID  # noqa: PLW0603
 
     task = TaskResponse(
         id=_NEXT_ID,
-        title=req_model.title,
-        description=req_model.description,
-        priority=req_model.priority,
+        title=body.title,
+        description=body.description,
+        priority=body.priority,
         done=False,
     )
     _TASKS[_NEXT_ID] = task.model_dump()
@@ -176,9 +176,9 @@ def delete_task(req: func.HttpRequest, path: TaskPath) -> func.HttpResponse:
 
 This catches accidental response drift early.
 
-### Step 3: implement create with `request_model`
+### Step 3: implement create with `body`
 
-`request_model=TaskCreateRequest` is concise and injects `req_model`.
+`body=TaskCreateRequest` validates the request body and injects `body`.
 
 ### Step 4: implement PATCH safely
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -73,18 +73,18 @@ Typical approach for file uploads:
 
 ## What is the difference between `body` and `request_model`?
 
-- `body=Model`: validates request body and injects `body` parameter.
-- `request_model=Model`: shorthand alias for body validation and injects
-  `req_model` parameter.
-
-They are functionally similar for single-source body validation.
+- `body=Model`: validates request body and injects `body` parameter. **Preferred.**
+- `request_model=Model`: **deprecated** alias for `body` that injects a
+  `req_model` parameter and emits a `DeprecationWarning`. Use `body=` instead.
 
 ```python
+# Preferred:
 @validate_http(body=CreateBody)
 def a(req: func.HttpRequest, body: CreateBody) -> dict[str, str]:
     return {"name": body.name}
 
 
+# Deprecated (emits DeprecationWarning):
 @validate_http(request_model=CreateBody)
 def b(req: func.HttpRequest, req_model: CreateBody) -> dict[str, str]:
     return {"name": req_model.name}

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserRes
 - `query`: query string validation.
 - `path`: route parameter validation.
 - `headers`: header validation.
-- `request_model`: shorthand alias for body validation.
+- `request_model`: **deprecated** alias for `body` (emits `DeprecationWarning`; use `body=`).
 
 ### Response validation
 
@@ -85,9 +85,10 @@ def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserRes
 - Invalid response payloads return a `500` with a safe validation envelope.
 - Returning `func.HttpResponse` bypasses model validation intentionally.
 
-!!! warning "Use `request_model` carefully"
-    `request_model` cannot be combined with `body`, `query`, `path`, or `headers`.
-    Use explicit `body=...` when validating multiple input sources.
+!!! warning "`request_model` is deprecated"
+    `request_model` is a deprecated alias for `body` and emits a
+    `DeprecationWarning`. Use explicit `body=...` instead. It cannot be
+    combined with `body`, `query`, `path`, or `headers`.
 
 ## Where to go next
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -163,7 +163,12 @@ def search(
     Use combined validation when each source has distinct semantics:
     body for domain payload, query for paging/filtering, headers for metadata.
 
-## `request_model` shorthand
+## `request_model` shorthand (deprecated)
+
+!!! warning "Deprecated — use `body`"
+    `request_model` is a deprecated alias for `body` and emits a
+    `DeprecationWarning`. Prefer `body=` (which injects a parameter named
+    `body`). `request_model` will be removed in a future release.
 
 `request_model` is shorthand for body validation and injects `req_model`.
 
@@ -172,9 +177,10 @@ class CreateTaskBody(BaseModel):
     title: str
 
 
-@validate_http(request_model=CreateTaskBody)
-def create_task(req: func.HttpRequest, req_model: CreateTaskBody) -> dict[str, str]:
-    return {"title": req_model.title}
+# Preferred:
+@validate_http(body=CreateTaskBody)
+def create_task(req: func.HttpRequest, body: CreateTaskBody) -> dict[str, str]:
+    return {"title": body.title}
 ```
 
 !!! warning "Non-combinable shorthand"

--- a/examples/crud_api/README.md
+++ b/examples/crud_api/README.md
@@ -19,6 +19,5 @@ A realistic task management REST API that demonstrates the full range of
 - **Body + query combination** — list endpoint filters via query params
 - **Path parameter validation** — `task_id` with `ge=1` constraint
 - **List response model** — `response_model=list[TaskResponse]`
-- **`request_model` shorthand** — `request_model=TaskCreateRequest` instead of `body=`
 - **HttpResponse bypass** — delete returns `204 No Content` directly
 - **Partial update** — `model_dump(exclude_unset=True)` pattern for PATCH

--- a/examples/crud_api/function_app.py
+++ b/examples/crud_api/function_app.py
@@ -133,9 +133,9 @@ def get_task(req: func.HttpRequest, path: TaskPath) -> dict[str, object]:
 
 @app.function_name(name="create_task")
 @app.route(route="tasks", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
-@validate_http(request_model=TaskCreateRequest, response_model=TaskResponse)
-def create_task(req: func.HttpRequest, req_model: TaskCreateRequest) -> TaskResponse:
-    """Create a new task using the request_model shorthand.
+@validate_http(body=TaskCreateRequest, response_model=TaskResponse)
+def create_task(req: func.HttpRequest, body: TaskCreateRequest) -> TaskResponse:
+    """Create a new task using body validation.
 
     POST /api/tasks  {"title": "New task", "priority": 2}
     """
@@ -143,9 +143,9 @@ def create_task(req: func.HttpRequest, req_model: TaskCreateRequest) -> TaskResp
 
     task = TaskResponse(
         id=_NEXT_ID,
-        title=req_model.title,
-        description=req_model.description,
-        priority=req_model.priority,
+        title=body.title,
+        description=body.description,
+        priority=body.priority,
         done=False,
     )
     _TASKS[_NEXT_ID] = task.model_dump()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -335,7 +335,7 @@ class TestCrudGetTask:
 
 
 class TestCrudCreateTask:
-    """POST /api/tasks — create via request_model shorthand."""
+    """POST /api/tasks — create via body validation."""
 
     def setup_method(self) -> None:
         self.mod = _crud_module()


### PR DESCRIPTION
## Summary

Docs-vs-code sync for v0.11.1 (same class of drift fixed in sibling `azure-functions-openapi` #409/PR#412).

- **`request_model` deprecation**: code emits a `DeprecationWarning` (steering to `body=`) but user-facing docs taught it as a normal shorthand. Now marked deprecated in `api.md`, `configuration.md`, `usage.md`, `index.md`, `faq.md`.
- **`crud_api` example migrated to `body=`** (example + README + test docstring) so it no longer emits a release-blocking `DeprecationWarning`. Verified: `pytest tests/test_examples.py -k CrudCreateTask` passes with `PYTHONWARNINGS=error::DeprecationWarning` (5 passed, 0 warnings).
- **Adapter public-status fixed**: `ValidationAdapter`/`PydanticAdapter`/`HttpError` are in `__all__` but docs called adapters "internal". Fixed `api.md` Public surface note + added a public "Custom adapters" section; fixed `architecture.md` exports list.
- **`api.md` structural bugs**: removed orphaned malformed JSON block and a duplicate `loc` line.

## Verification

- `ruff check` clean on changed `.py`.
- Pre-commit hooks passed (ruff, format).
- crud example tests pass with DeprecationWarnings-as-errors.
- Docs-only + one example migration; no public API surface change.

## Out of scope

- README / translations untouched (docs/ only).
- Stray untracked `*_readme.md` files in the worktree are pre-existing, not committed.

Closes #310