### PR TITLE
docs(metadata): reframe endpoint metadata doc as a convention

### DIFF
--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -1,8 +1,16 @@
-# `endpoint` metadata namespace — SPEC
+# `endpoint` metadata convention — `azure-functions-validation` conformance
 
 Status: **v1** · Owner namespace: `endpoint` · Issue: [#271](https://github.com/yeongseon/azure-functions-validation-python/issues/271) · Umbrella: [#270](https://github.com/yeongseon/azure-functions-validation-python/issues/270)
 
-> **Localization:** This specification is an English-only technical document
+> **Canonical contract:** The neutral, canonical home for the `endpoint`
+> metadata contract is
+> [`azure-functions-python-dx` › `docs/endpoint-contract.md`](https://github.com/yeongseon/azure-functions-python-dx/blob/main/docs/endpoint-contract.md).
+> This document is **not** that source of truth — it is a **convention**, not a
+> centralized binding spec. What follows describes how `azure-functions-validation`
+> conforms to the shared convention: its own emitted payload, canonicalization
+> rules, and internal (non-published) conformance artifacts.
+
+> **Localization:** This document is an English-only technical document
 > (the JSON Schema it links to is an internal conformance artifact of this
 > package, not a source of truth other packages bind to).
 > It is intentionally **not** part of the translated README set


### PR DESCRIPTION
## Summary
Resolves the self-contradiction in `docs/METADATA_SPEC.md`: the "SPEC" title implied a centralized binding spec, while the body correctly describes the shipped JSON Schema as an internal, non-binding conformance artifact.

## Changes
- Retitle H1 → `endpoint` metadata **convention** — `azure-functions-validation` conformance.
- Add a top-of-file pointer to the neutral canonical hub ([`azure-functions-python-dx` › `docs/endpoint-contract.md`](https://github.com/yeongseon/azure-functions-python-dx/blob/main/docs/endpoint-contract.md)), framing this doc as this package's conformance against the shared convention.
- Soften the localization note wording ("This document" vs "This specification").
- Body text (internal conformance artifact, per-package local tests, vendored helpers) unchanged.

## Scope notes
- No code, filename, or test-helper changes (file rename / relocation deferred per #313 out-of-scope).
- README and translated READMEs do not reference the doc title, so no translation sync required (AGENTS.md rule checked).

Closes #313
