### PR TITLE
chore(deps): document azure-functions 2.0 readiness and add opt-in compat spike

### DIFF
--- a/docs/azure-functions-2.0-readiness.md
+++ b/docs/azure-functions-2.0-readiness.md
@@ -101,7 +101,12 @@ normalized to `<2.0.0` everywhere:
 | azure-functions-langgraph | `>=1.17,<2.0.0` |
 | azure-functions-knowledge | `>=1.22.0,<2.0.0` |
 | azure-functions-scaffold | `>=1.23.0,<2.0.0` |
-| azure-functions-durable-graph | `>=1.17,<2.0.0` (normalized from `<3`) |
+| azure-functions-durable-graph | `>=1.17,<2.0.0` |
+
+> `azure-functions-durable-graph` additionally caps the separate
+> `azure-functions-durable` extension at `<3`; that is a different package with
+> its own release cadence and is **not** part of this worker-introspection
+> contract.
 
 > The upper bound is the load-bearing part. Lower bounds vary by the minimum
 > feature each package needs and are not part of the 2.0 readiness contract.

--- a/docs/azure-functions-2.0-readiness.md
+++ b/docs/azure-functions-2.0-readiness.md
@@ -1,0 +1,124 @@
+# azure-functions 2.0 readiness
+
+This document is the canonical tracker for the `azure-functions>=1.17,<2.0.0`
+dependency cap in `azure-functions-validation` (and, by extension, the wider
+Azure Functions Python DX Toolkit). It records **why** the `<2.0.0` cap exists,
+**what** would have to be verified before it is lifted, and **how** to detect a
+break against a candidate `azure-functions` 2.x release.
+
+> **Status:** cap in place. The cap-lift conditions below are **not yet
+> verified** against a released `azure-functions` 2.x. See
+> [`tests/test_worker_compat_2x_spike.py`](../tests/test_worker_compat_2x_spike.py)
+> for the opt-in spike that verifies them once a 2.x candidate is available.
+
+## Why the cap exists
+
+`@validate_http` replaces the user's handler with a wrapper whose *visible*
+signature is a single `req` positional plus a hidden `**_kw` catch-all. The
+Azure Functions Python worker (`azure_functions_worker`, specifically
+`index_function_app` / `loader.py`) does **not** call the handler through a
+stable public API — it *introspects* the registered callable to index it and to
+build its binding map. `WorkerCompat`
+(`src/azure_functions_validation/decorator.py`) exists solely to make our
+wrapper survive that introspection.
+
+Because these are **worker-internal, introspection-based** contracts rather than
+documented public APIs, a major `azure-functions` release (2.0) is the most
+likely place for them to change. The cap is conservative on purpose: we would
+rather block an untested major than ship a silently non-registering decorator
+(the failure mode is an app that deploys "successfully" but exposes **zero**
+functions).
+
+## The five worker-internal behaviors we depend on
+
+`WorkerCompat.apply()` shims each of these. If `azure-functions` 2.x preserves
+all five (or `WorkerCompat` is updated to match 2.x), the cap can be lifted.
+
+1. **`co_argcount` / `co_varnames` trigger-param discovery.** The worker
+   inspects the code object of the registered callable to locate the HTTP
+   trigger parameter. A `*args`/`**kwargs`-only wrapper has `co_argcount == 0`
+   and is **silently skipped**, producing an empty function list on the deployed
+   app. We declare a real `req` positional (`co_argcount == 1`).
+   *See `_make_wrapper` docstring.*
+
+2. **`__signature__` override to hide `**_kw`.** The worker reads
+   `inspect.signature()` and rejects params "declared in Python but not in the
+   function definition." An exposed `**_kw` raises
+   `FunctionLoadError: ... {'_kw'}` at load time. We set `wrapper.__signature__`
+   to expose `req` plus the passthrough binding params only.
+   *See `WorkerCompat._override_signature`.*
+
+3. **No `__wrapped__`.** `functools.update_wrapper` sets `__wrapped__ = func`,
+   and some worker builds follow it back to the *original* handler, see
+   `co_argcount > 1`, and fail to register. We copy only `SAFE_IDENTITY_ATTRS`
+   via `copy_identity_attrs` and deliberately never set `__wrapped__`.
+   *See `WorkerCompat._copy_safe_metadata`.*
+
+4. **`get_type_hints`-based binding resolution against handler globals.** The
+   worker resolves binding annotations with `get_type_hints` against the
+   *handler's* module globals. Our wrapper lives in a different module, so we
+   pre-resolve passthrough annotations to concrete type objects at decoration
+   time (handles PEP 563 `from __future__ import annotations` string
+   annotations). *See `WorkerCompat._resolve_passthrough_annotations`.*
+
+5. **`req` left unannotated.** With `req: typing.Any` the worker raises
+   `binding req has invalid non-type annotation`; with no annotation it falls
+   back to `HttpRequest` type inference, which is what we want. We set
+   `__annotations__` to the passthrough binding types only, never `req`.
+   *See `WorkerCompat._set_annotations`.*
+
+## Cap-lift conditions
+
+The `<2.0.0` cap may be lifted to (e.g.) `<3.0.0` when **all** of the following
+hold:
+
+- [ ] A released (non-prerelease) `azure-functions` 2.x is available on PyPI.
+- [ ] The opt-in spike (`tests/test_worker_compat_2x_spike.py`) passes against
+      that 2.x with **zero** new `RuntimeWarning` / `DeprecationWarning` from
+      `@validate_http`.
+- [ ] A real Azure deployment (the release-certification e2e in `e2e-azure.yml`)
+      registers `@validate_http` handlers and serves them — i.e. the deployed
+      function list is **non-empty** and requests validate as expected.
+- [ ] If any of the five behaviors changed, `WorkerCompat` is updated and its
+      unit tests (`tests/test_decorator.py::TestReqContextWorkerIndexing` and
+      neighbors) still lock the exposed-signature invariants.
+
+Lifting the cap is a coordinated fleet action: the same cap lives in every DX
+Toolkit library (see below), and they should move together to avoid a resolver
+split in downstream apps.
+
+## Fleet cap inventory
+
+All toolkit libraries cap `azure-functions` below the next major. As of this
+writing the lower bounds differ (historical), but the upper bound is being
+normalized to `<2.0.0` everywhere:
+
+| Package | Cap |
+| --- | --- |
+| azure-functions-validation | `>=1.17,<2.0.0` |
+| azure-functions-openapi | `>=1.21.0,<2.0.0` |
+| azure-functions-db | `>=1.22.0,<2.0.0` |
+| azure-functions-langgraph | `>=1.17,<2.0.0` |
+| azure-functions-knowledge | `>=1.22.0,<2.0.0` |
+| azure-functions-scaffold | `>=1.23.0,<2.0.0` |
+| azure-functions-durable-graph | `>=1.17,<2.0.0` (normalized from `<3`) |
+
+> The upper bound is the load-bearing part. Lower bounds vary by the minimum
+> feature each package needs and are not part of the 2.0 readiness contract.
+
+## How to run the spike
+
+The spike is **off by default** — it is excluded from normal CI (`-m 'not e2e
+and not compat2x'`) and additionally gated on an environment variable so a bare
+`pytest -m compat2x` does not accidentally reinstall `azure-functions` in a
+developer's working environment:
+
+```bash
+# In a throwaway virtualenv — the spike may install a 2.x/prerelease build.
+export AZFUNC_2X_SPIKE=1
+pip install --pre --upgrade 'azure-functions>=2.0.0.dev0'   # or a real 2.x when released
+pytest -m compat2x -o addopts='' tests/test_worker_compat_2x_spike.py
+```
+
+If the spike passes cleanly, capture the `azure-functions` version and attach it
+to the tracking issue as evidence toward the cap-lift checklist above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,10 +138,13 @@ module = "examples.*"
 follow_imports = "skip"
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/azure_functions_validation --cov-report=xml --cov-report=term-missing -ra -q -m 'not e2e'"
+addopts = "--cov=src/azure_functions_validation --cov-report=xml --cov-report=term-missing -ra -q -m 'not e2e and not compat2x'"
 testpaths = ["tests"]
 pythonpath = ["src", ".", "examples", "tests/_test_app"]
-markers = ["e2e: real Azure end-to-end tests (require E2E_BASE_URL)"]
+markers = [
+    "e2e: real Azure end-to-end tests (require E2E_BASE_URL)",
+    "compat2x: opt-in azure-functions 2.x compatibility spike (require AZFUNC_2X_SPIKE=1)",
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_worker_compat_2x_spike.py
+++ b/tests/test_worker_compat_2x_spike.py
@@ -1,0 +1,123 @@
+"""Opt-in spike: verify @validate_http survives the installed azure-functions worker.
+
+This module is **off by default**. It is:
+
+* marked ``compat2x`` and excluded from the default ``addopts``
+  (``-m 'not e2e and not compat2x'``), and
+* additionally gated on the ``AZFUNC_2X_SPIKE`` environment variable,
+
+so it never runs in normal CI or in a bare ``pytest`` invocation. Its purpose is
+to be run **manually** against a candidate ``azure-functions`` 2.x build to
+verify the five worker-internal behaviors that ``WorkerCompat`` depends on (see
+``docs/azure-functions-2.0-readiness.md``) before the ``<2.0.0`` cap is lifted.
+
+Run it like::
+
+    export AZFUNC_2X_SPIKE=1
+    pytest -m compat2x -o addopts='' tests/test_worker_compat_2x_spike.py
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+import inspect
+import os
+
+import azure.functions as func
+from azure.functions import HttpRequest, HttpResponse
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_validation import validate_http
+
+pytestmark = [
+    pytest.mark.compat2x,
+    pytest.mark.skipif(
+        os.environ.get("AZFUNC_2X_SPIKE") != "1",
+        reason="opt-in spike; set AZFUNC_2X_SPIKE=1 to run against a candidate build",
+    ),
+]
+
+
+class _Body(BaseModel):
+    name: str
+
+
+def _registered_functions(app: func.FunctionApp) -> list[object]:
+    """Return the app's indexed function list across worker API variants."""
+    getter = getattr(app, "get_functions", None)
+    if callable(getter):
+        return list(getter())
+    # Fallback for builds that only expose the underlying registry.
+    registry = getattr(app, "_function_builders", None)
+    return list(registry) if registry is not None else []
+
+
+def test_spike_reports_installed_version(recwarn: pytest.WarningsRecorder) -> None:
+    """Capture the azure-functions version under test (evidence for the cap-lift checklist)."""
+    installed = version("azure-functions")
+    assert installed  # non-empty
+    print(f"\n[compat2x] azure-functions=={installed}")
+
+
+def test_exposed_signature_stays_single_req() -> None:
+    """Behavior 1 & 2: co_argcount == 1 and no leaked ``**_kw``."""
+
+    @validate_http(body=_Body)
+    def handler(req: HttpRequest, body: _Body) -> HttpResponse:
+        return HttpResponse("ok")
+
+    assert list(inspect.signature(handler).parameters) == ["req"]
+    assert handler.__code__.co_argcount == 1
+
+
+def test_no_dunder_wrapped() -> None:
+    """Behavior 3: ``__wrapped__`` must never be set (worker would follow it)."""
+
+    @validate_http(body=_Body)
+    def handler(req: HttpRequest, body: _Body) -> HttpResponse:
+        return HttpResponse("ok")
+
+    assert not hasattr(handler, "__wrapped__")
+
+
+def test_req_left_unannotated() -> None:
+    """Behavior 5: ``req`` carries no annotation so the worker infers HttpRequest."""
+
+    @validate_http(body=_Body)
+    def handler(req: HttpRequest, body: _Body) -> HttpResponse:
+        return HttpResponse("ok")
+
+    assert "req" not in handler.__annotations__
+
+
+def test_worker_indexes_validate_http_handler() -> None:
+    """End-to-end: the worker must produce a NON-EMPTY function list.
+
+    This is the load-bearing assertion for the 2.0 cap. A wrapper the worker
+    cannot index deploys "successfully" but exposes zero functions.
+    """
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @app.route(route="users", methods=["POST"])
+    @validate_http(body=_Body)
+    def create_user(req: HttpRequest, body: _Body) -> HttpResponse:
+        return HttpResponse("ok")
+
+    functions = _registered_functions(app)
+    assert len(functions) >= 1, "worker indexed zero functions — @validate_http wrapper was skipped"
+
+
+def test_worker_indexes_handler_with_output_binding() -> None:
+    """Passthrough binding params must remain visible + annotated to the worker."""
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @app.route(route="events", methods=["POST"])
+    @app.queue_output(arg_name="out_msg", queue_name="q", connection="AzureWebJobsStorage")
+    @validate_http(body=_Body)
+    def emit(req: HttpRequest, body: _Body, out_msg: func.Out[str]) -> HttpResponse:
+        out_msg.set(body.name)
+        return HttpResponse("ok")
+
+    functions = _registered_functions(app)
+    assert len(functions) >= 1


### PR DESCRIPTION
## Context

Part of #312. The `azure-functions>=1.17,<2.0.0` cap exists because
`@validate_http`'s `WorkerCompat` relies on **worker-internal, introspection-based**
behaviors (not documented public APIs), which a major `azure-functions` 2.0 could
change. This PR documents those dependencies and the cap-lift conditions, and adds
an off-by-default spike to verify them against a candidate 2.x build.

## Changes

- **`docs/azure-functions-2.0-readiness.md`** — canonical cap tracker: why the cap
  exists, the five worker dependencies (`co_argcount`, `__signature__` hiding
  `**_kw`, no `__wrapped__`, `get_type_hints` binding resolution, unannotated
  `req`), a cap-lift checklist, the fleet cap inventory, and how to run the spike.
- **`tests/test_worker_compat_2x_spike.py`** — env-gated (`AZFUNC_2X_SPIKE=1`),
  marked `compat2x`, **excluded from default `addopts`** so it never runs in normal
  CI. Asserts the single-`req` exposed signature, absence of `__wrapped__`, an
  unannotated `req`, and a **non-empty worker function list** (including an
  output-binding handler). Passes today against installed 1.x, so the invariants
  are locked and the spike is meaningful.
- **`pyproject.toml`** — register the `compat2x` marker and exclude it from default
  `addopts` (`-m 'not e2e and not compat2x'`).

## Verification

- `make lint` / `make typecheck` — clean.
- Default `pytest` — 98.31% coverage (≥95 gate), `compat2x` deselected.
- `AZFUNC_2X_SPIKE=1 pytest -m compat2x -o addopts=''` — 6 passed against 1.x.

## Out of scope

- Lifting the cap (blocked on a released 2.x + real-Azure certification).
- Fleet cap **lower-bound** normalization; the durable-graph upper-bound
  `<3` → `<2.0.0` normalization is tracked separately in that repo.

Refs #312