### PR TITLE
docs(i18n): adopt best-effort translation policy with staleness banners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,9 @@
 - The version test in `tests/test_public_api.py` reads from `importlib.metadata` and needs no manual edits across releases.
 
 ### Documentation & Translations
-- When a change touches `README.md` or any English documentation, update the translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) **in the same PR** so translations never drift from the English source.
-- This applies to any code change that alters documented behavior, CLI output, or the ecosystem/package table — not just direct edits to prose.
-- If a full translation cannot land in the same PR, add a short "translation pending" note to the affected translated file and open a tracking issue before merging.
+- English (`README.md`) is the **canonical** source of truth for all documentation. Translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) are **best-effort**, community-maintained, and may lag the English source.
+- Translation sync is **not** required in the same PR as an English change, and a PR is **never** blocked by translation drift. Update translations opportunistically; when you do, keep them faithful to the current English source.
+- Each translated README carries a staleness banner linking back to the canonical English README. Keep that banner in place so readers always know the translation may be out of date.
 
 ## Issue Conventions
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,6 +13,8 @@
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
+> ℹ️ この翻訳はコミュニティによる参考用であり、最新の [English README](README.md) より古い場合があります。正確な最新情報は英語版を参照してください。
+
 **Azure Functions Python v2 プログラミング モデル**向けの validation と serialization を提供します。
 このパッケージは、decorator ベースの `FunctionApp` HTTP ハンドラー向けに typed request parsing と response validation を提供します。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,6 +13,8 @@
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
+> ℹ️ 이 번역은 커뮤니티가 관리하는 참고용 문서로, 최신 [English README](README.md)보다 뒤처질 수 있습니다. 정확한 최신 정보는 영어 원문을 기준으로 하세요.
+
 **Azure Functions Python v2 프로그래밍 모델**을 위한 validation 및 serialization 라이브러리입니다.
 이 패키지는 decorator 기반 `FunctionApp` HTTP 핸들러를 위한 typed request parsing과 response validation을 제공합니다.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,8 @@
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
 
+> ℹ️ 本翻译由社区维护，仅供参考，可能落后于最新的 [English README](README.md)。请以英文版为准。
+
 为 **Azure Functions Python v2 编程模型**提供 validation 和 serialization。
 该包为基于 decorator 的 `FunctionApp` HTTP 处理函数提供 typed request parsing 和 response validation。
 


### PR DESCRIPTION
## Context

Closes #314. The 4-language README set with a **mandatory same-PR translation-sync**
rule was a large, drift-prone surface (4 files/repo per documented-behavior change
across ~9 repos). Per the evaluation on #314, this adopts **Option B**: English is
the single canonical source; translations are best-effort and community-maintained;
a PR is never blocked by translation drift. No translations are deleted.

## Changes

- **`AGENTS.md`** — rewrite *Documentation & Translations*: English `README.md` is
  canonical; translated READMEs are best-effort and may lag; same-PR sync is **not**
  required and never blocks a PR; keep the per-file staleness banner.
- **`README.ko.md` / `README.ja.md` / `README.zh-CN.md`** — add a localized staleness
  banner linking back to the canonical `README.md`.

## Converged policy (applies fleet-wide)

This is the reference implementation; sibling repos get the identical AGENTS.md
policy and localized banners via their own tracking issues + PRs.

## Out of scope

- Rewriting or retranslating existing translation content.
- Deleting any translated README.