### PR TITLE
ci: automate release-gate action floor bumps via Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,7 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps)"
-    labels:
-      - "dependencies"
-      - "github-actions"
-    open-pull-requests-limit: 10
+# NOTE: GitHub Actions bumps are handled by Renovate (renovate.json), not
+# Dependabot, so a single PR can update both the workflow `uses:` SHA and the
+# canonical pin in tools/lint_release_workflows.py and keep the drift lint green.
+# See issue #320.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["github-actions", "custom.regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Keep CANONICAL_ACTIONS pins in tools/lint_release_workflows.py in sync with the workflow uses: SHAs so bot-authored bumps pass the drift lint.",
+      "managerFilePatterns": ["^tools/lint_release_workflows\\.py$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n\\s*\"[^\"]+\": \\(\"(?<currentDigest>[a-f0-9]{40})\", \"(?<currentValue>v[^\"]+)\"\\)"
+      ],
+      "autoReplaceStringTemplate": "# renovate: datasource={{{datasource}}} depName={{{depName}}} versioning={{{versioning}}}\n    \"{{{depName}}}\": (\"{{{newDigest}}}\", \"{{{newValue}}}\")"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group the five release-gate action bumps so the workflow pin and the CANONICAL_ACTIONS constant land in one PR that keeps the drift lint green.",
+      "matchManagers": ["github-actions", "custom.regex"],
+      "matchPackageNames": [
+        "actions/checkout",
+        "actions/setup-python",
+        "azure/login",
+        "actions/upload-artifact",
+        "actions/download-artifact"
+      ],
+      "groupName": "release-gate GitHub Actions pins"
+    }
+  ]
+}

--- a/tools/lint_release_workflows.py
+++ b/tools/lint_release_workflows.py
@@ -37,10 +37,15 @@ import sys
 
 # --- Fleet-wide canonical pins (action -> (sha, annotation)) ------------------
 CANONICAL_ACTIONS: dict[str, tuple[str, str]] = {
+    # renovate: datasource=github-tags depName=actions/checkout versioning=github-tags
     "actions/checkout": ("3d3c42e5aac5ba805825da76410c181273ba90b1", "v7.0.1"),
+    # renovate: datasource=github-tags depName=actions/setup-python versioning=github-tags
     "actions/setup-python": ("5fda3b95a4ea91299a34e894583c3862153e4b97", "v7.0.0"),
+    # renovate: datasource=github-tags depName=azure/login versioning=github-tags
     "azure/login": ("f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca", "v3.0.1"),
+    # renovate: datasource=github-tags depName=actions/upload-artifact versioning=github-tags
     "actions/upload-artifact": ("ea165f8d65b6e75b540449e92b4886f43607fa02", "v4"),
+    # renovate: datasource=github-tags depName=actions/download-artifact versioning=github-tags
     "actions/download-artifact": ("d3f86a106a0bac45b974a628896c90dbdf5c8093", "v4"),
 }
 


### PR DESCRIPTION
## Context

Bumping the five canonical release-gate action SHAs was fully manual. The drift lint (`tools/lint_release_workflows.py`) requires the workflow `uses:` SHA **and** the `CANONICAL_ACTIONS` constant to match, so a naive Dependabot github-actions PR would bump only the workflow and fail its own gate. This wires Renovate so a single grouped PR updates both places and stays green. Follow-up to #306 / umbrella #308.

## What changed

- **`renovate.json`** — built-in `github-actions` manager + a `custom.regex` manager that rewrites the `CANONICAL_ACTIONS` pins in the lint tool. A `packageRules` group lands the workflow pin and the constant in one PR (`release-gate GitHub Actions pins`).
- **`tools/lint_release_workflows.py`** — each `CANONICAL_ACTIONS` entry now carries a `# renovate: datasource=github-tags depName=... versioning=github-tags` comment the custom manager targets. No SHA/behaviour change.
- **`.github/dependabot.yml`** — dropped the `github-actions` ecosystem (now owned by Renovate) to avoid duplicate bump PRs; `pip` retained.

## Acceptance Checklist

- [x] Renovate proposes pinned-SHA bumps for the five gate actions with annotation updates.
- [x] Bumps keep the SHA + `# vX.Y.Z` annotation in sync (custom manager rewrites both digest and value).
- [x] Drift lint passes with the annotated constants (`python tools/lint_release_workflows.py` clean; `tests/test_release_workflow_pins.py` green).

## Verification

- `python tools/lint_release_workflows.py` → canonical, exit 0
- `pytest tests/test_release_workflow_pins.py` → 8 passed
- `renovate.json` valid JSON; `dependabot.yml` valid YAML

## References
- #306, #308

Closes #320