### PR TITLE
ci: add fleet-wide workflow pin-hygiene lint

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -305,4 +305,4 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1 # pin-exempt: PyPA official publisher (trusted-publisher OIDC); tracks release/v1 by design

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ check-schema-hash: ensure-hatch
 .PHONY: lint-workflows
 lint-workflows: ensure-hatch
 	@$(HATCH) run python tools/lint_release_workflows.py
+	@$(HATCH) run python tools/lint_workflow_pins.py
 
 
 .PHONY: check

--- a/tests/test_workflow_pin_hygiene.py
+++ b/tests/test_workflow_pin_hygiene.py
@@ -1,0 +1,63 @@
+"""Regression guard for the fleet-wide workflow pin-hygiene lint.
+
+Exercises tools/lint_workflow_pins.py against this repo (must be clean) and
+against synthetic drift (must be caught). Keeps the vendored lint honest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LINT_PATH = _REPO_ROOT / "tools" / "lint_workflow_pins.py"
+
+_spec = importlib.util.spec_from_file_location("lint_workflow_pins", _LINT_PATH)
+assert _spec and _spec.loader
+lint_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint_mod)
+
+
+def test_repo_workflows_are_pin_clean() -> None:
+    """Every committed workflow must satisfy pin-hygiene."""
+    assert lint_mod.lint() == []
+
+
+def test_sha_with_comment_passes() -> None:
+    text = "      - uses: actions/checkout@" + "a" * 40 + " # v7.0.1\n"
+    assert lint_mod.check_pin_hygiene(text, "fake.yml") == []
+
+
+def test_local_composite_action_passes() -> None:
+    text = "      - uses: ./.github/actions/setup\n"
+    assert lint_mod.check_pin_hygiene(text, "fake.yml") == []
+
+
+def test_documented_exception_passes() -> None:
+    text = "      - uses: pypa/gh-action-pypi-publish@release/v1 # pin-exempt: trusted publisher\n"
+    assert lint_mod.check_pin_hygiene(text, "fake.yml") == []
+
+
+def test_unpinned_tag_fails() -> None:
+    text = "      - uses: actions/checkout@v4\n"
+    errors = lint_mod.check_pin_hygiene(text, "fake.yml")
+    assert errors and "not a 40-hex" in errors[0]
+
+
+def test_branch_ref_without_exemption_fails() -> None:
+    text = "      - uses: pypa/gh-action-pypi-publish@release/v1\n"
+    errors = lint_mod.check_pin_hygiene(text, "fake.yml")
+    assert errors and "not a 40-hex" in errors[0]
+
+
+def test_sha_without_version_comment_fails() -> None:
+    text = "      - uses: actions/checkout@" + "b" * 40 + "\n"
+    errors = lint_mod.check_pin_hygiene(text, "fake.yml")
+    assert errors and "missing the trailing" in errors[0]
+
+
+def test_pin_exempt_marker_requires_a_reason() -> None:
+    # A bare "pin-exempt" with no reason must NOT satisfy the exemption.
+    text = "      - uses: pypa/gh-action-pypi-publish@release/v1 # pin-exempt:\n"
+    errors = lint_mod.check_pin_hygiene(text, "fake.yml")
+    assert errors and "not a 40-hex" in errors[0]

--- a/tools/lint_workflow_pins.py
+++ b/tools/lint_workflow_pins.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Fleet-wide pin-hygiene lint for GitHub Actions workflows.
+
+Part of the DX Toolkit CI hardening work
+(follow-up to yeongseon/azure-functions-validation-python#319, umbrella #308).
+
+Unlike ``tools/lint_release_workflows.py`` -- which enforces a single *canonical*
+SHA per action for the two release-gate workflows -- this lint applies a lighter
+**pin-hygiene** rule to *every* workflow file. It does not care *which* version an
+action is pinned to (that is Renovate's domain, #320); it only insists the pin is
+a real, immutable commit SHA (or an explicitly justified exception).
+
+Rule -- every external ``uses:`` reference MUST be one of:
+
+1. Pinned to a full 40-hex commit SHA **and** carry a trailing ``#`` version
+   comment (e.g. ``uses: actions/checkout@<sha> # v7.0.1``); or
+2. A local composite action (``uses: ./...``); or
+3. An explicitly documented exception flagged with an inline ``# pin-exempt:``
+   comment at the call site, stating why the SHA pin is skipped (e.g. the PyPA
+   ``gh-action-pypi-publish`` trusted-publisher action, or a distributed
+   copy-paste template file).
+
+Enforcing pin *hygiene* rather than a canonical SHA keeps non-gate workflows free
+to be bumped by Renovate/Dependabot without fighting a frozen central version.
+
+Stdlib-only on purpose: the lint must not itself depend on a package that can
+drift. Exit code 0 = clean, 1 = drift detected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+WORKFLOWS_DIR = ".github/workflows"
+
+# owner/name@ref, with an optional trailing "# comment".
+_USES_RE = re.compile(
+    r"""uses:\s*(?P<ref>\S+)          # the action reference (owner/name@x or ./local)
+        (?:\s+\#\s*(?P<comment>.*\S))?  # optional trailing # comment
+        \s*$
+    """,
+    re.VERBOSE,
+)
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+# Marker that justifies skipping a SHA pin. Must carry a reason after the colon.
+_EXEMPT_RE = re.compile(r"pin-exempt:\s*\S")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _split_ref(ref: str) -> tuple[str, str | None]:
+    """Split ``owner/name@gitref`` into (action, gitref). Local actions have no @."""
+    if "@" not in ref:
+        return ref, None
+    action, _, gitref = ref.partition("@")
+    return action, gitref
+
+
+def check_pin_hygiene(text: str, rel_path: str) -> list[str]:
+    """Assert every external ``uses:`` is SHA-pinned, local, or documented-exempt."""
+    errors: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        m = _USES_RE.search(line)
+        if not m:
+            continue
+        ref = m.group("ref")
+        comment = m.group("comment")
+
+        # (2) Local composite actions are always allowed.
+        if ref.startswith("./") or ref.startswith("."):
+            continue
+
+        action, gitref = _split_ref(ref)
+
+        # (3) Explicitly documented exception, e.g. the PyPA publish action.
+        if comment and _EXEMPT_RE.search(comment):
+            continue
+
+        if gitref is None:
+            errors.append(
+                f"{rel_path}:{lineno}: '{ref}' is not pinned "
+                f"(no @ref); pin to a 40-hex SHA or mark '# pin-exempt: <reason>'"
+            )
+            continue
+
+        # (1) Full commit SHA + trailing version comment.
+        if _SHA_RE.match(gitref):
+            if not comment:
+                errors.append(
+                    f"{rel_path}:{lineno}: {action}@{gitref} is SHA-pinned but "
+                    f"missing the trailing '# <version>' comment"
+                )
+            continue
+
+        errors.append(
+            f"{rel_path}:{lineno}: {action} is pinned to '{gitref}', not a 40-hex "
+            f"commit SHA; pin to a SHA (with a version comment) or mark "
+            f"'# pin-exempt: <reason>'"
+        )
+    return errors
+
+
+def lint(root: Path | None = None) -> list[str]:
+    """Run pin-hygiene over every workflow file; return human-readable violations."""
+    root = root or _repo_root()
+    errors: list[str] = []
+    workflows = root / WORKFLOWS_DIR
+    if not workflows.is_dir():
+        return [f"{WORKFLOWS_DIR}: expected workflows directory is missing"]
+    for path in sorted(workflows.glob("*.yml")) + sorted(workflows.glob("*.yaml")):
+        rel = path.relative_to(root).as_posix()
+        errors.extend(check_pin_hygiene(path.read_text(encoding="utf-8"), rel))
+    return errors
+
+
+def main() -> int:
+    errors = lint()
+    if errors:
+        print("Workflow pin-hygiene drift detected:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print("Workflow pin-hygiene: every action is SHA-pinned, local, or documented-exempt.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context

Follow-up to #319. The release-gate drift lint (`tools/lint_release_workflows.py`, #306/#318) enforces a single *canonical* SHA per action for the two gate workflows only. #319 concluded (Oracle-reviewed) that *non-gate* workflows should get lightweight **pin-hygiene** enforcement instead of strict canonical pins — strict pins would fight Renovate/Dependabot and freeze non-gate workflows to a central version forever.

## What changed

- **`tools/lint_workflow_pins.py`** (new, stdlib-only) — scans every `.github/workflows/*.yml`. Each external `uses:` must be one of:
  1. a full 40-hex commit SHA **with** a trailing `# <version>` comment, or
  2. a local composite action (`./...`), or
  3. an inline-documented `# pin-exempt: <reason>` exception.
  It intentionally does **not** assert a canonical SHA (that stays the gate lint's + Renovate's job).
- **`publish-pypi.yml`** — flag the PyPA `gh-action-pypi-publish@release/v1` line with `# pin-exempt:` (trusted-publisher OIDC action, tracks `release/v1` by design), matching the AGENTS.md exception rule.
- **`tests/test_workflow_pin_hygiene.py`** — unit tests: SHA+comment passes; local `./...` passes; documented exception passes; unpinned tag / bare branch ref / SHA-without-comment / reasonless marker all fail; committed workflows are clean.
- **`Makefile`** — `lint-workflows` now runs both lints, so it is covered by `check-all`.

## Acceptance Checklist

- [x] Pin-hygiene lint covering all workflow files, with the narrow exemption set.
- [x] Unit tests for pass/fail cases.
- [x] Wired into `check-all`.
- [ ] Roll across the 8 sibling repos with per-repo issue + PR (tracked as follow-ups per the #318 pattern).

## Verification

- `python tools/lint_workflow_pins.py` → clean, exit 0
- `python tools/lint_release_workflows.py` → still canonical (regression)
- `pytest tests/test_workflow_pin_hygiene.py` → 8 passed
- `pytest tests/test_release_workflow_pins.py` → 8 passed (regression)

## References
- #319 (Oracle scope decision), #306, #318, #320

Refs #321 (umbrella; closed after sibling rollout)
