### PR TITLE
docs: consolidate official documentation URL onto yeongseon.dev (STEP 3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://yeongseon.github.io/azure-functions-validation-python/
+    url: https://yeongseon.dev/azure-functions-python/validation/
     about: Check our documentation for usage guides and examples

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/validation/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
@@ -69,7 +69,7 @@ flowchart LR
 | PyPI package   | `azure-functions-validation`        |
 | Python import  | `azure_functions_validation`        |
 
-リポジトリ名は Python 実装であることを示すために `-python` サフィックスを付けています。PyPI パッケージ名は Python エコシステムの慣例に従いサフィックスを付けずに公開されているため、インストールは自然に `pip install azure-functions-validation` のままです。詳細は [FAQ](https://yeongseon.github.io/azure-functions-validation-python/faq/#why-does-the-repo-use--python-but-the-pypi-package-does-not) を参照してください。
+リポジトリ名は Python 実装であることを示すために `-python` サフィックスを付けています。PyPI パッケージ名は Python エコシステムの慣例に従いサフィックスを付けずに公開されているため、インストールは自然に `pip install azure-functions-validation` のままです。詳細は [FAQ](https://yeongseon.dev/azure-functions-python/validation/faq/#why-does-the-repo-use-python-but-the-pypi-package-does-not) を参照してください。
 
 ## Installation
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/validation/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -69,7 +69,7 @@ flowchart LR
 | PyPI package   | `azure-functions-validation`        |
 | Python import  | `azure_functions_validation`        |
 
-저장소 이름에는 Python 구현체임을 표시하기 위해 `-python` 접미사가 붙어 있습니다. PyPI 패키지명은 Python 생태계 관례에 맞춰 접미사 없이 게시되므로 설치 명령은 `pip install azure-functions-validation`으로 자연스럽게 유지됩니다. 자세한 설명은 [FAQ](https://yeongseon.github.io/azure-functions-validation-python/faq/#why-does-the-repo-use--python-but-the-pypi-package-does-not)를 참고하세요.
+저장소 이름에는 Python 구현체임을 표시하기 위해 `-python` 접미사가 붙어 있습니다. PyPI 패키지명은 Python 생태계 관례에 맞춰 접미사 없이 게시되므로 설치 명령은 `pip install azure-functions-validation`으로 자연스럽게 유지됩니다. 자세한 설명은 [FAQ](https://yeongseon.dev/azure-functions-python/validation/faq/#why-does-the-repo-use-python-but-the-pypi-package-does-not)를 참고하세요.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/validation/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -214,7 +214,7 @@ Three names cover three different contexts:
 | PyPI package   | `azure-functions-validation`        |
 | Python import  | `azure_functions_validation`        |
 
-The repository carries the `-python` suffix to mark it as the Python implementation. The PyPI package follows Python ecosystem conventions and is published without the suffix, so installation stays idiomatic: `pip install azure-functions-validation`. See the [FAQ entry](https://yeongseon.github.io/azure-functions-validation-python/faq/#why-does-the-repo-use--python-but-the-pypi-package-does-not) for the long version.
+The repository carries the `-python` suffix to mark it as the Python implementation. The PyPI package follows Python ecosystem conventions and is published without the suffix, so installation stays idiomatic: `pip install azure-functions-validation`. See the [FAQ entry](https://yeongseon.dev/azure-functions-python/validation/faq/#why-does-the-repo-use-python-but-the-pypi-package-does-not) for the long version.
 
 ## Installation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-validation-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-validation-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-validation-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-validation-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/validation/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
@@ -69,7 +69,7 @@ flowchart LR
 | PyPI package   | `azure-functions-validation`        |
 | Python import  | `azure_functions_validation`        |
 
-仓库名带有 `-python` 后缀，用于标识其为 Python 实现。PyPI 包名遵循 Python 生态约定，不带后缀，因此安装命令仍然是自然的 `pip install azure-functions-validation`。详细说明请参阅 [FAQ](https://yeongseon.github.io/azure-functions-validation-python/faq/#why-does-the-repo-use--python-but-the-pypi-package-does-not)。
+仓库名带有 `-python` 后缀，用于标识其为 Python 实现。PyPI 包名遵循 Python 生态约定，不带后缀，因此安装命令仍然是自然的 `pip install azure-functions-validation`。详细说明请参阅 [FAQ](https://yeongseon.dev/azure-functions-python/validation/faq/#why-does-the-repo-use-python-but-the-pypi-package-does-not)。
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserRes
 For dependency setup details, see [Installation](installation.md).
 
 !!! info "About the names"
-    The repository is `azure-functions-validation-python`, the PyPI package is `azure-functions-validation`, and the import is `azure_functions_validation`. See the [FAQ](faq.md#why-does-the-repo-use--python-but-the-pypi-package-does-not) for why.
+    The repository is `azure-functions-validation-python`, the PyPI package is `azure-functions-validation`, and the import is `azure_functions_validation`. See the [FAQ](faq.md#why-does-the-repo-use-python-but-the-pypi-package-does-not) for why.
 
 ## Example Index
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,21 +5,21 @@
 Part of the **Azure Functions Python DX Toolkit**. Pydantic-powered request validation and response serialization for HTTP-triggered functions — validate body, query, path, and header parameters with a decorator, bringing a FastAPI-like developer experience to Azure Functions. Install from PyPI with `pip install azure-functions-validation`.
 
 ## Getting Started
-- [Installation](https://yeongseon.github.io/azure-functions-validation-python/installation/): Install the package.
-- [Quickstart](https://yeongseon.github.io/azure-functions-validation-python/getting-started/): Minimal end-to-end example.
-- [Configuration](https://yeongseon.github.io/azure-functions-validation-python/configuration/): Customize validation behavior.
+- [Installation](https://yeongseon.dev/azure-functions-python/validation/installation/): Install the package.
+- [Quickstart](https://yeongseon.dev/azure-functions-python/validation/getting-started/): Minimal end-to-end example.
+- [Configuration](https://yeongseon.dev/azure-functions-python/validation/configuration/): Customize validation behavior.
 
 ## User Guide
-- [Usage](https://yeongseon.github.io/azure-functions-validation-python/usage/): Decorator reference and models.
-- [Architecture](https://yeongseon.github.io/azure-functions-validation-python/architecture/): How the validation pipeline works.
+- [Usage](https://yeongseon.dev/azure-functions-python/validation/usage/): Decorator reference and models.
+- [Architecture](https://yeongseon.dev/azure-functions-python/validation/architecture/): How the validation pipeline works.
 
 ## Examples
-- [Basic Validation](https://yeongseon.github.io/azure-functions-validation-python/examples/basic_validation/): Body validation.
-- [Query/Path/Header](https://yeongseon.github.io/azure-functions-validation-python/examples/query_validation/): Non-body parameters.
-- [Async Validation](https://yeongseon.github.io/azure-functions-validation-python/examples/async_validation/): Async handlers.
-- [CRUD API](https://yeongseon.github.io/azure-functions-validation-python/examples/crud_api/): Full example.
+- [Basic Validation](https://yeongseon.dev/azure-functions-python/validation/examples/basic_validation/): Body validation.
+- [Query/Path/Header](https://yeongseon.dev/azure-functions-python/validation/examples/query_validation/): Non-body parameters.
+- [Async Validation](https://yeongseon.dev/azure-functions-python/validation/examples/async_validation/): Async handlers.
+- [CRUD API](https://yeongseon.dev/azure-functions-python/validation/examples/crud_api/): Full example.
 
 ## Reference
-- [API Reference](https://yeongseon.github.io/azure-functions-validation-python/api/): Public API surface.
-- [FAQ](https://yeongseon.github.io/azure-functions-validation-python/faq/): Frequently asked questions.
-- [Troubleshooting](https://yeongseon.github.io/azure-functions-validation-python/troubleshooting/): Common issues and fixes.
+- [API Reference](https://yeongseon.dev/azure-functions-python/validation/api/): Public API surface.
+- [FAQ](https://yeongseon.dev/azure-functions-python/validation/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.dev/azure-functions-python/validation/troubleshooting/): Common issues and fixes.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -367,7 +367,7 @@ if meta and "validation" in meta:
     This is the integration point used by `azure-functions-openapi`'s
     `scan_validation_metadata()` bridge to auto-generate OpenAPI specs from
     validation decorators. See the
-    [azure-functions-openapi docs](https://yeongseon.github.io/azure-functions-openapi/)
+    [azure-functions-openapi docs](https://yeongseon.dev/azure-functions-python/openapi/)
     for details.
 
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Version: see package metadata
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-validation-python/
+- Docs: https://yeongseon.dev/azure-functions-python/validation/
 - Repository: https://github.com/yeongseon/azure-functions-validation-python
 - Azure Functions programming model: v2
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - Version: see package metadata
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-validation-python/
+- Docs: https://yeongseon.dev/azure-functions-python/validation/
 - Repository: https://github.com/yeongseon/azure-functions-validation-python
 
 ## What It Does
@@ -57,9 +57,9 @@ def create_user(req: func.HttpRequest, body: CreateUserRequest) -> CreateUserRes
 
 ## Documentation
 
-- [Getting Started](https://yeongseon.github.io/azure-functions-validation-python/getting-started/)
-- [API Reference](https://yeongseon.github.io/azure-functions-validation-python/api/)
-- [Deployment Guide](https://yeongseon.github.io/azure-functions-validation-python/deployment/)
+- [Getting Started](https://yeongseon.dev/azure-functions-python/validation/getting-started/)
+- [API Reference](https://yeongseon.dev/azure-functions-python/validation/api/)
+- [Deployment Guide](https://yeongseon.dev/azure-functions-python/validation/deployment/)
 
 ## Ecosystem
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Azure Functions Validation
 site_description: Validation and serialization for Python-based Azure Functions
 site_author: Yeongseon Choe
-site_url: https://yeongseon.github.io/azure-functions-validation-python/
+site_url: https://yeongseon.dev/azure-functions-python/validation/
 repo_url: https://github.com/yeongseon/azure-functions-validation-python
 edit_uri: edit/main/docs/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://yeongseon.github.io/azure-functions-validation-python/"
-Documentation = "https://yeongseon.github.io/azure-functions-validation-python/"
+Homepage = "https://yeongseon.dev/azure-functions-python/validation/"
+Documentation = "https://yeongseon.dev/azure-functions-python/validation/"
 Repository = "https://github.com/yeongseon/azure-functions-validation-python"
 Issues = "https://github.com/yeongseon/azure-functions-validation-python/issues"
 


### PR DESCRIPTION
## Summary
Consolidate the official documentation URL onto **https://yeongseon.dev/azure-functions-python/validation/**.

- `pyproject.toml`: `Homepage` / `Documentation` → new URL. `Repository` / `Issues` unchanged.
- `mkdocs.yml`: `site_url` → new URL. `repo_url` / `edit_uri` unchanged (GitHub).
- README (en/ja/ko/zh-CN): docs link → new URL; stale `docs-gh--pages` badge label → `docs-yeongseon.dev`.
- `llms.txt`, `llms-full.txt`, `docs/llms.txt`, `.github/ISSUE_TEMPLATE/config.yml`: legacy `github.io` doc links → new URL (subpaths preserved).
- **FAQ anchor fix**: the new site slugifies the heading as `#why-does-the-repo-use-python-...` (single dash) vs the old `--python` (double dash). Updated the FAQ deep-links in all READMEs and the internal `docs/index.md` link accordingly.
- **Cross-tool link**: `docs/usage.md` linked to the openapi tool via the (now-404) `github.io/azure-functions-openapi/`; remapped to its new route `https://yeongseon.dev/azure-functions-python/openapi/` (not to this package's root).

## Verification
- All new `/validation/` subpaths (installation, getting-started, configuration, usage, architecture, examples/*, api, faq, troubleshooting, deployment) return HTTP 200.
- New site FAQ anchor `#why-does-the-repo-use-python-but-the-pypi-package-does-not` confirmed present; old double-dash form absent.
- No `yeongseon.github.io` references remain in tracked files.
- `mkdocs build --strict`: the only remaining strict warning (`azure-functions-2.0-readiness.md` → `../tests/...` missing target) is **pre-existing on `main`** and unrelated to this PR.

## Notes
- Old GitHub Pages site is served via a redirect stub (canonical + 0s meta refresh + visible link + hash-preserving JS); not an HTTP 301.
- No PyPI release in this pass (STEP 5).

Closes #332