### PR TITLE
fix(decorator): resolve passthrough annotations per-parameter

### DIFF
--- a/src/azure_functions_validation/decorator.py
+++ b/src/azure_functions_validation/decorator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import types
 from typing import Any, Callable, Mapping, get_type_hints
 import warnings
 
@@ -344,11 +345,43 @@ class WorkerCompat:
         """
         if not passthrough:
             return {}
+        # Fast path: resolve every annotation in one pass.
         try:
             hints = get_type_hints(func)
         except Exception:  # pragma: no cover - defensive; user-module resolution
-            hints = {}
-        return {name: hints[name] for name, _param in passthrough if name in hints}
+            hints = None
+        if hints is not None:
+            return {name: hints[name] for name, _param in passthrough if name in hints}
+        # Fallback: a single unresolvable annotation must not drop *all* binding
+        # annotations (all-or-nothing get_type_hints failure). Resolve each
+        # passthrough param independently so the surviving bindings stay typed.
+        func_globals = getattr(func, "__globals__", {})
+        resolved: dict[str, Any] = {}
+        for name, param in passthrough:
+            annotation = self._resolve_one_annotation(param.annotation, func_globals)
+            if annotation is not inspect.Parameter.empty:
+                resolved[name] = annotation
+        return resolved
+
+    @staticmethod
+    def _resolve_one_annotation(annotation: Any, func_globals: Mapping[str, Any]) -> Any:
+        """Resolve a single (possibly stringized) annotation in isolation.
+
+        Returns ``inspect.Parameter.empty`` when the annotation is absent or
+        cannot be resolved, so one bad annotation never poisons the others.
+        Resolution reuses ``get_type_hints`` on a throwaway probe carrying only
+        this annotation (no ``eval``), evaluated against the handler's globals.
+        """
+        if annotation is inspect.Parameter.empty:
+            return inspect.Parameter.empty
+        if not isinstance(annotation, str):
+            return annotation
+        probe = types.FunctionType((lambda: None).__code__, dict(func_globals))
+        probe.__annotations__ = {"a": annotation}
+        try:
+            return get_type_hints(probe).get("a", inspect.Parameter.empty)
+        except Exception:  # pragma: no cover - user annotation resolution
+            return inspect.Parameter.empty
 
     def _override_signature(
         self,

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -425,6 +425,38 @@ class TestPassthroughBindingParams:
         assert handler.__annotations__ == {"order_doc": func.Out[str]}
         assert not hasattr(handler, "__wrapped__")
 
+    def test_unresolvable_annotation_preserves_other_bindings(self) -> None:
+        """One unresolvable annotation must not strip resolvable binding types.
+
+        ``get_type_hints`` is all-or-nothing: a single unresolvable forward
+        reference makes it raise, which previously dropped *every* passthrough
+        annotation and left the worker unable to validate real output bindings.
+        The fallback resolves each param independently so survivors stay typed.
+        """
+        import inspect
+
+        import azure.functions as func
+
+        @validate_http(body=UserModel)
+        def handler(
+            req: HttpRequest,
+            body: UserModel,
+            order_doc: func.Out[str],
+            mystery: "DoesNotExistType",  # type: ignore[name-defined]  # noqa: F821 - intentionally unresolvable
+        ) -> HttpResponse:
+            return HttpResponse("ok")
+
+        # All passthrough params stay visible to the worker...
+        assert list(inspect.signature(handler).parameters) == [
+            "req",
+            "order_doc",
+            "mystery",
+        ]
+        # ...and the resolvable binding keeps its concrete annotation even though
+        # ``mystery`` could not be resolved (it is simply left unannotated).
+        assert handler.__annotations__ == {"order_doc": func.Out[str]}
+        assert "mystery" not in handler.__annotations__
+
     def test_input_binding_param_is_exposed_and_forwarded(self) -> None:
         import inspect
 


### PR DESCRIPTION
## Summary
- `get_type_hints()` is all-or-nothing; one unresolvable annotation previously dropped **all** passthrough binding annotations, weakening `func.Out[...]` validation.
- Keep the fast path when every hint resolves; otherwise resolve each passthrough param in isolation via a throwaway `get_type_hints` probe (no `eval`) so resolvable bindings retain concrete types.
- Add regression test `test_unresolvable_annotation_preserves_other_bindings`.

Closes #340