### PR TITLE
ci(docs): add screenshot provenance manifest + staleness checker

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -204,6 +204,33 @@ jobs:
         env:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
 
+      # Best-effort provenance capture of live endpoint responses. Non-gating
+      # (continue-on-error): a screenshot failure must never block certification.
+      # A maintainer later registers captured images in docs/assets/screenshots.yml
+      # (method: playwright) and embeds them in the docs.
+      - name: Capture endpoint screenshots
+        if: always()
+        continue-on-error: true
+        env:
+          E2E_APP_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+          OUT_DIR: screenshots
+          CAPTURE_SHA: ${{ inputs.ref || github.sha }}
+          CAPTURE_VERSION: ${{ inputs.version }}
+        run: |
+          npm install --no-save playwright@1.54.1
+          npx playwright install --with-deps chromium
+          node scripts/capture_screenshots.mjs
+
+      - name: Upload screenshots
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: endpoint-screenshots-${{ github.run_id }}-${{ github.run_attempt }}
+          path: screenshots/
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Record certification
         run: |
           SHA=$(git rev-parse HEAD)

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,35 @@
+name: screenshots
+
+# Validates docs/assets/screenshots.yml on pull requests: fails on structural
+# problems (invalid manifest, missing image, missing source input, duplicate id)
+# and warns (without failing) when declared source inputs changed but the
+# manifest was not refreshed — that drift is expected to be reviewed by a human
+# who then re-captures the screenshot via the e2e-azure workflow.
+on:
+  pull_request:
+    paths:
+      - docs/assets/screenshots.yml
+      - scripts/check_screenshots.py
+      - examples/**
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check screenshot manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Install checker dependencies
+        run: pip install pyyaml
+
+      - name: Run staleness checker
+        run: python scripts/check_screenshots.py

--- a/docs/assets/screenshots.yml
+++ b/docs/assets/screenshots.yml
@@ -1,0 +1,34 @@
+# Screenshot provenance manifest.
+#
+# Records where each documentation screenshot came from so drift can be
+# detected automatically. `source.hash` is a combined SHA-256 over the
+# `source.inputs` files (see scripts/check_screenshots.py); when those inputs
+# change, the recomputed hash no longer matches and the screenshot is flagged
+# as potentially stale and in need of re-capture.
+#
+# This manifest is seeded EMPTY on purpose: the provenance pipeline (checker +
+# staleness workflow + e2e-azure capture step) is in place, but no screenshot
+# has been captured yet. The Azure Release Certification workflow
+# (.github/workflows/e2e-azure.yml) captures live endpoint screenshots against a
+# real deployment; a maintainer then adds an entry here (method: playwright),
+# embeds the image in the docs, and refreshes the hash with
+# `python scripts/check_screenshots.py --update`.
+#
+# `captured` fields are provenance only — they are never used for staleness
+# decisions (that is what `source.hash` is for).
+#
+# schema_version 1 entry shape:
+#   id:        stable unique identifier (kebab/underscore)
+#   image:     repo-relative path to the PNG
+#   captured:
+#     package_version: version the screenshot was captured against
+#     git_sha:         commit the screenshot was captured against
+#     date:            ISO-8601 capture (or seed) date
+#     method:          "manual" | "playwright"
+#   source:
+#     inputs: [repo-relative files whose change invalidates the screenshot]
+#     hash:   combined sha256 over inputs (recomputed by the checker)
+#   output:  (optional)
+#     hash:  sha256 of the image bytes, for tamper/regeneration tracking
+schema_version: 1
+screenshots: []

--- a/scripts/capture_screenshots.mjs
+++ b/scripts/capture_screenshots.mjs
@@ -1,0 +1,126 @@
+// Live endpoint screenshot capture for the Azure Release Certification workflow.
+//
+// Runs against a freshly deployed e2e_app on real Azure and renders each
+// endpoint's HTTP response into a styled page, then screenshots it. The three
+// captures demonstrate the package end to end: a healthy GET, a validated
+// create (200), and the standardized 422 validation-error envelope.
+//
+// Resilient by design: a failure to reach one endpoint is recorded in
+// metadata.json and never aborts the run, so screenshot capture can never gate
+// a release certification.
+import { chromium } from "playwright";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const BASE_URL = (process.env.E2E_APP_URL || "").replace(/\/+$/, "");
+const OUT_DIR = process.env.OUT_DIR || "screenshots";
+const VERSION = process.env.CAPTURE_VERSION || "";
+const SHA = process.env.CAPTURE_SHA || "";
+
+const targets = [
+  { id: "e2e_app_health", method: "GET", path: "/api/health" },
+  {
+    id: "e2e_app_items_created",
+    method: "POST",
+    path: "/api/items",
+    body: { name: "widget", quantity: 3 },
+  },
+  {
+    id: "e2e_app_items_validation_error",
+    method: "POST",
+    path: "/api/items",
+    body: { name: "", quantity: 0 },
+  },
+];
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function renderPage(target, status, bodyText) {
+  const curlBody = target.body ? ` -d '${JSON.stringify(target.body)}'` : "";
+  const request = `${target.method} ${target.path}`;
+  let pretty = bodyText;
+  try {
+    pretty = JSON.stringify(JSON.parse(bodyText), null, 2);
+  } catch {
+    /* leave raw body as-is */
+  }
+  return `<!doctype html><html><head><meta charset="utf-8"><style>
+    body { margin: 0; background: #0d1117; color: #e6edf3;
+      font-family: "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace; }
+    .wrap { padding: 28px 32px; }
+    .req { color: #7ee787; font-size: 18px; margin-bottom: 6px; }
+    .curl { color: #8b949e; font-size: 13px; margin-bottom: 18px; }
+    .status { font-size: 15px; margin-bottom: 14px; }
+    .ok { color: #7ee787; } .err { color: #ff7b72; }
+    pre { background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+      padding: 18px 20px; font-size: 15px; line-height: 1.5; margin: 0; }
+  </style></head><body><div class="wrap">
+    <div class="req">${escapeHtml(request)}</div>
+    <div class="curl">curl -X ${target.method} ${escapeHtml(BASE_URL + target.path)}${escapeHtml(curlBody)}</div>
+    <div class="status">HTTP <span class="${status >= 200 && status < 400 ? "ok" : "err"}">${status}</span></div>
+    <pre>${escapeHtml(pretty)}</pre>
+  </div></body></html>`;
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1000, height: 640 } });
+  const records = [];
+
+  for (const target of targets) {
+    const record = {
+      id: target.id,
+      image: `${target.id}.png`,
+      request: `${target.method} ${target.path}`,
+      method: "playwright",
+    };
+    try {
+      const init = { method: target.method, headers: {} };
+      if (target.body) {
+        init.headers["Content-Type"] = "application/json";
+        init.body = JSON.stringify(target.body);
+      }
+      const res = await fetch(BASE_URL + target.path, init);
+      const text = await res.text();
+      record.http_status = res.status;
+      await page.setContent(renderPage(target, res.status, text), {
+        waitUntil: "load",
+      });
+      await page.screenshot({ path: join(OUT_DIR, `${target.id}.png`) });
+      record.captured = true;
+    } catch (err) {
+      record.captured = false;
+      record.error = String(err);
+    }
+    records.push(record);
+  }
+
+  await browser.close();
+  await writeFile(
+    join(OUT_DIR, "metadata.json"),
+    JSON.stringify(
+      {
+        package_version: VERSION,
+        git_sha: SHA,
+        base_url: BASE_URL,
+        captured_at: new Date().toISOString(),
+        method: "playwright",
+        screenshots: records,
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`Captured ${records.filter((r) => r.captured).length}/${records.length} screenshot(s).`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/check_screenshots.py
+++ b/scripts/check_screenshots.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Staleness checker for documentation screenshots.
+
+Reads ``docs/assets/screenshots.yml`` and verifies that every screenshot is
+well-formed and still matches the source it was captured from. It recomputes a
+combined SHA-256 over each entry's ``source.inputs`` and compares it against the
+declared ``source.hash``.
+
+The manifest may legitimately be *empty* (``screenshots: []``) while the
+provenance pipeline is in place but no screenshot has been captured yet — this
+repository seeds the manifest empty and populates it after the first real-Azure
+capture via ``.github/workflows/e2e-azure.yml``. An empty manifest is therefore
+treated as clean, not as an error.
+
+Failure modes are split by severity so this can gate PRs without blocking on
+expected, human-reviewed drift:
+
+Hard failures (exit 1):
+  * manifest missing / unreadable / not ``schema_version: 1``
+  * ``screenshots`` is not a list
+  * missing required keys, duplicate ``id``, malformed entry
+  * declared ``image`` file does not exist
+  * declared ``source.inputs`` file does not exist
+
+Soft warnings (exit 0, unless ``--strict``):
+  * recomputed source hash differs from the declared hash — the inputs changed
+    but the manifest (and likely the screenshot) was not refreshed
+
+``--update`` rewrites ``source.hash`` / ``output.hash`` in place after a
+re-capture, so maintainers do not compute hashes by hand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import sys
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "docs" / "assets" / "screenshots.yml"
+
+_REQUIRED_CAPTURED = ("package_version", "git_sha", "date", "method")
+
+
+def _combined_source_hash(inputs: list[str]) -> str:
+    digest = hashlib.sha256()
+    for rel in sorted(inputs):
+        digest.update(rel.encode() + b"\0")
+        digest.update((REPO_ROOT / rel).read_bytes() + b"\0")
+    return "sha256:" + digest.hexdigest()
+
+
+def _image_hash(rel: str) -> str:
+    return "sha256:" + hashlib.sha256((REPO_ROOT / rel).read_bytes()).hexdigest()
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("manifest root must be a mapping")
+    if data.get("schema_version") != 1:
+        raise ValueError(f"unsupported schema_version: {data.get('schema_version')!r} (expected 1)")
+    screenshots = data.get("screenshots")
+    # An empty list is valid: the pipeline is seeded before any capture exists.
+    if not isinstance(screenshots, list):
+        raise ValueError("manifest 'screenshots' must be a list")
+    return data
+
+
+def _validate_entry(entry: Any, index: int) -> tuple[list[str], str, list[str]]:
+    """Return (hard_errors, entry_id, source_inputs) for one entry."""
+    errors: list[str] = []
+    if not isinstance(entry, dict):
+        return [f"screenshots[{index}] must be a mapping"], "", []
+
+    entry_id = entry.get("id")
+    if not isinstance(entry_id, str) or not entry_id:
+        errors.append(f"screenshots[{index}] missing string 'id'")
+        entry_id = ""
+
+    image = entry.get("image")
+    if not isinstance(image, str) or not image:
+        errors.append(f"{entry_id or index}: missing string 'image'")
+    elif not (REPO_ROOT / image).is_file():
+        errors.append(f"{entry_id or index}: image not found: {image}")
+
+    captured = entry.get("captured")
+    if not isinstance(captured, dict):
+        errors.append(f"{entry_id or index}: missing 'captured' mapping")
+    else:
+        for key in _REQUIRED_CAPTURED:
+            if key not in captured:
+                errors.append(f"{entry_id or index}: captured.{key} is required")
+
+    source = entry.get("source")
+    inputs: list[str] = []
+    if not isinstance(source, dict):
+        errors.append(f"{entry_id or index}: missing 'source' mapping")
+    else:
+        raw_inputs = source.get("inputs")
+        if not isinstance(raw_inputs, list) or not raw_inputs:
+            errors.append(f"{entry_id or index}: source.inputs must be a non-empty list")
+        else:
+            for rel in raw_inputs:
+                if not isinstance(rel, str) or not (REPO_ROOT / rel).is_file():
+                    errors.append(f"{entry_id or index}: source input not found: {rel}")
+                else:
+                    inputs.append(rel)
+        if "hash" not in source:
+            errors.append(f"{entry_id or index}: source.hash is required")
+
+    return errors, entry_id, inputs
+
+
+def _check(path: Path, strict: bool) -> int:
+    try:
+        manifest = _load_manifest(path)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"screenshot manifest invalid: {exc}")
+        return 1
+
+    hard_errors: list[str] = []
+    warnings: list[str] = []
+    seen_ids: set[str] = set()
+
+    for index, entry in enumerate(manifest["screenshots"]):
+        entry_errors, entry_id, inputs = _validate_entry(entry, index)
+        hard_errors.extend(entry_errors)
+        if entry_id:
+            if entry_id in seen_ids:
+                hard_errors.append(f"duplicate id: {entry_id}")
+            seen_ids.add(entry_id)
+        if entry_errors or not inputs:
+            continue
+        declared = entry["source"].get("hash")
+        actual = _combined_source_hash(inputs)
+        if declared != actual:
+            warnings.append(
+                f"{entry_id}: source inputs changed since capture "
+                f"(declared {declared}, actual {actual}); re-capture screenshot "
+                f"and refresh the manifest"
+            )
+
+    if hard_errors:
+        print("Screenshot manifest check FAILED:")
+        for err in hard_errors:
+            print(f"  error: {err}")
+        return 1
+
+    if warnings:
+        print("Screenshot manifest drift detected:")
+        for warn in warnings:
+            print(f"  warning: {warn}")
+        if strict:
+            return 1
+        return 0
+
+    print(f"Screenshot manifest OK: {len(seen_ids)} screenshot(s) verified.")
+    return 0
+
+
+def _update(path: Path) -> int:
+    manifest = _load_manifest(path)
+    for entry in manifest["screenshots"]:
+        source = entry["source"]
+        source["hash"] = _combined_source_hash(list(source["inputs"]))
+        if "output" in entry and isinstance(entry["output"], dict):
+            entry["output"]["hash"] = _image_hash(entry["image"])
+    path.write_text(
+        yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    print(f"Updated hashes for {len(manifest['screenshots'])} screenshot(s).")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat source-hash drift warnings as failures",
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="recompute and rewrite source/output hashes in place",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.manifest.is_file():
+        print(f"screenshot manifest not found: {args.manifest}")
+        return 1
+    if args.update:
+        return _update(args.manifest)
+    return _check(args.manifest, strict=args.strict)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_screenshot_manifest.py
+++ b/tests/test_screenshot_manifest.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_screenshots.py"
+MANIFEST = REPO_ROOT / "docs" / "assets" / "screenshots.yml"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_committed_manifest_is_clean() -> None:
+    result = _run("--strict")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "verified" in result.stdout
+
+
+def test_valid_manifest_matches_source_inputs() -> None:
+    result = _run("--manifest", str(MANIFEST))
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def _write(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+
+
+def test_empty_manifest_is_valid(tmp_path: Path) -> None:
+    manifest = tmp_path / "m.yml"
+    _write(manifest, "schema_version: 1\nscreenshots: []\n")
+    result = _run("--manifest", str(manifest), "--strict")
+    assert result.returncode == 0
+    assert "0 screenshot(s) verified" in result.stdout
+
+
+def test_unsupported_schema_version_fails(tmp_path: Path) -> None:
+    manifest = tmp_path / "m.yml"
+    _write(manifest, "schema_version: 2\n")
+    result = _run("--manifest", str(manifest))
+    assert result.returncode == 1
+    assert "schema_version" in result.stdout
+
+
+def test_missing_image_and_duplicate_id_fail(tmp_path: Path) -> None:
+    manifest = tmp_path / "m.yml"
+    _write(
+        manifest,
+        """
+        schema_version: 1
+        screenshots:
+          - id: dupe
+            image: docs/assets/does_not_exist.png
+            captured: {package_version: "0.0.0", git_sha: x, date: "2026-01-01", method: manual}
+            source: {inputs: [examples/e2e_app/function_app.py], hash: "sha256:x"}
+          - id: dupe
+            image: examples/e2e_app/function_app.py
+            captured: {package_version: "0.0.0", git_sha: x, date: "2026-01-01", method: manual}
+            source: {inputs: [examples/e2e_app/function_app.py], hash: "sha256:x"}
+        """,
+    )
+    result = _run("--manifest", str(manifest))
+    assert result.returncode == 1
+    assert "image not found" in result.stdout
+    assert "duplicate id: dupe" in result.stdout
+
+
+def test_source_drift_warns_but_passes_without_strict(tmp_path: Path) -> None:
+    manifest = tmp_path / "m.yml"
+    _write(
+        manifest,
+        """
+        schema_version: 1
+        screenshots:
+          - id: drift
+            image: examples/e2e_app/function_app.py
+            captured: {package_version: "0.0.0", git_sha: x, date: "2026-01-01", method: manual}
+            source: {inputs: [examples/e2e_app/function_app.py], hash: "sha256:stale"}
+        """,
+    )
+    ok = _run("--manifest", str(manifest))
+    assert ok.returncode == 0
+    assert "drift detected" in ok.stdout
+
+    strict = _run("--manifest", str(manifest), "--strict")
+    assert strict.returncode == 1
+    assert "drift detected" in strict.stdout


### PR DESCRIPTION
## Context

Ports the screenshot-provenance pipeline from the sibling [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) repo (its #408) into this repo. Scope for this PR is **pipeline plumbing only** — no real-Azure deployment is triggered here. The manifest is seeded empty; live images are captured on a future `e2e-azure` dispatch and registered by a maintainer.

## What's added

- **`docs/assets/screenshots.yml`** — `schema_version: 1` provenance manifest, seeded empty (`screenshots: []`).
- **`scripts/check_screenshots.py`** — staleness checker. Hard-fails on structural problems (invalid manifest, missing image/source input, duplicate id); warns (non-gating, unless `--strict`) on source-hash drift. Adapted from the sibling to **tolerate an empty manifest** so the pipeline can land before any capture exists. `--update` refreshes hashes after a re-capture.
- **`tests/test_screenshot_manifest.py`** — subprocess tests: clean/empty manifest, unsupported schema, missing-image + duplicate-id hard fail, drift warns-vs-strict.
- **`.github/workflows/screenshots.yml`** — PR workflow that runs the checker when the manifest, checker, or `examples/**` change.
- **`.github/workflows/e2e-azure.yml`** — non-gating (`continue-on-error`) capture + upload steps between the e2e run and certification.
- **`scripts/capture_screenshots.mjs`** — Playwright capture of the deployed `e2e_app`'s health (200), validated create (200), and 422 validation-error responses; resilient (never aborts a run) and writes `metadata.json` provenance.

## Verification

- `make check-all` green locally (ruff + mypy strict + full pytest + bandit).
- Coverage 98.31% (≥ 95% gate); source coverage unaffected (checker lives in `scripts/`, outside the coverage scope).
- `tools/lint_workflow_pins.py` and `tools/lint_release_workflows.py` pass — all new `uses:` are canonical SHA-pinned.

## Out of scope

- Triggering a real-Azure `e2e-azure` run and embedding captured images (follow-up, per plumbing-only scope).