### PR TITLE
docs: add screenshot capture runbook and manifest make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,14 @@ check-all: ensure-hatch
 	@$(MAKE) security
 	@echo "All checks passed including tests and security scan."
 
+.PHONY: screenshots-check
+screenshots-check: ensure-hatch
+	@$(HATCH) run python scripts/check_screenshots.py --strict
+
+.PHONY: screenshots-update
+screenshots-update: ensure-hatch
+	@$(HATCH) run python scripts/check_screenshots.py --update
+
 .PHONY: precommit
 precommit: ensure-hatch
 	@$(HATCH) run precommit

--- a/docs/screenshot-capture.md
+++ b/docs/screenshot-capture.md
@@ -1,0 +1,123 @@
+# Capturing and registering documentation screenshots
+
+This runbook explains how to capture Azure Portal resource screenshots for a
+deployed Function App and register them in the screenshot provenance pipeline so
+that [`scripts/check_screenshots.py`](https://github.com/yeongseon/azure-functions-validation-python/blob/main/scripts/check_screenshots.py)
+can detect when they go stale.
+
+> **Why this is a manual step.** Azure Portal pages require an authenticated
+> browser session (sign-in plus MFA), so portal *resource* screens cannot be
+> captured headlessly in CI. The `e2e-azure` workflow captures live *endpoint*
+> responses automatically, but the portal Overview/Functions views are captured
+> by a maintainer following this guide.
+
+## What the pipeline already gives you
+
+- **Manifest** — [`docs/assets/screenshots.yml`](assets/screenshots.yml) records
+  the provenance of every documentation screenshot. It is seeded **empty**
+  (`screenshots: []`), which the checker treats as clean.
+- **Checker** — `scripts/check_screenshots.py` hard-fails on missing images,
+  missing inputs, and duplicate ids; it warns (or, with `--strict`, fails) when
+  a screenshot's `source.inputs` change after capture.
+- **PR gate** — [`.github/workflows/screenshots.yml`](https://github.com/yeongseon/azure-functions-validation-python/blob/main/.github/workflows/screenshots.yml)
+  runs the checker on every pull request.
+
+Adding a manifest entry **before** the PNG exists will (correctly) fail the
+checker, so capture the image first, then register it.
+
+## Step 1 — Have a Function App to capture
+
+You need a deployed Function App resource in the portal. Either:
+
+- Use an existing deployment you already have, **or**
+- Follow [`docs/deployment.md`](deployment.md) to stand up a temporary Function
+  App, capture the screenshots, then tear it down (see
+  [Clean up resources](deployment.md#clean-up-resources)). Deleting the resource
+  group afterward keeps this a one-time, non-billing verification — consistent
+  with the [Verification status](deployment.md#verification-status) policy.
+
+## Step 2 — Capture the portal screens
+
+Sign in to [portal.azure.com](https://portal.azure.com), open your Function App
+resource, and capture:
+
+| Screen | Portal location | Suggested filename |
+| --- | --- | --- |
+| Overview | Function App → **Overview** | `docs/assets/portal-functionapp-overview.png` |
+| Functions list | Function App → **Functions** | `docs/assets/portal-functionapp-functions.png` |
+
+Before capturing, anonymize anything you would not publish: subscription id,
+resource group names that leak internal detail, and the public app URL if it is
+not already anonymized elsewhere in the docs.
+
+Save the PNGs at the paths above (or paths of your choosing — just keep the
+manifest `image` values in sync).
+
+## Step 3 — Register each screenshot in the manifest
+
+Add one entry per PNG to the `screenshots:` list in
+[`docs/assets/screenshots.yml`](assets/screenshots.yml). Use this shape (leave
+`source.hash` as a placeholder — Step 4 fills it in):
+
+```yaml
+screenshots:
+  - id: portal-functionapp-overview
+    image: docs/assets/portal-functionapp-overview.png
+    captured:
+      package_version: "0.11.2"      # output of `make version`
+      git_sha: "<commit-sha>"        # commit the capture was taken against
+      date: "2026-08-15"             # ISO-8601 capture date
+      method: manual                 # portal captures are always "manual"
+    source:
+      inputs:
+        - examples/e2e_app/function_app.py   # files whose change invalidates the shot
+      hash: "sha256:0"               # placeholder; refreshed by --update
+    output:
+      hash: "sha256:0"               # placeholder; refreshed by --update
+```
+
+Field notes:
+
+- **`source.inputs`** is the list of repo files whose change should flag the
+  screenshot as stale. For a portal view of the deployed app, point it at the
+  app definition (for example `examples/e2e_app/function_app.py`) so that
+  changing the deployed functions re-flags the portal shots.
+- **`captured.*`** fields are provenance only — they never drive staleness
+  decisions. `source.hash` does.
+- Every `id` must be unique across the manifest.
+
+## Step 4 — Refresh hashes and verify
+
+Recompute `source.hash` / `output.hash` from the files on disk, then run the
+checker:
+
+```bash
+make screenshots-update   # rewrites hashes in docs/assets/screenshots.yml
+make screenshots-check    # strict verification; must pass before you commit
+```
+
+`make screenshots-check` runs the checker with `--strict`, so any residual drift
+fails the command. A clean run prints `Screenshot manifest OK: N screenshot(s)
+verified.`
+
+## Step 5 — Embed and open a PR
+
+1. Reference the images where they are useful — typically in the
+   [Verification status](deployment.md#verification-status) section of
+   `docs/deployment.md`:
+
+   ```markdown
+   ![Function App Overview](assets/portal-functionapp-overview.png)
+   ![Functions list](assets/portal-functionapp-functions.png)
+   ```
+
+2. Commit the PNGs, the manifest changes, and the docs edit together
+   (`docs:` Conventional Commit) and open a PR. The
+   [`screenshots` workflow](https://github.com/yeongseon/azure-functions-validation-python/blob/main/.github/workflows/screenshots.yml)
+   re-runs the checker on the PR.
+
+## When a screenshot goes stale
+
+If you later change a file listed in an entry's `source.inputs`, the checker
+warns that the capture no longer matches its source. Re-capture the affected
+portal screen, replace the PNG, and re-run Step 4 to refresh the hashes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
   - Contributing:
       - Development: development.md
       - Testing: testing.md
+      - Screenshot Capture: screenshot-capture.md
       - Guidelines: contributing.md
   - Troubleshooting: troubleshooting.md
   - FAQ: faq.md


### PR DESCRIPTION
## Context

Follow-up to #342 (screenshot provenance pipeline). The remaining task — embedding **real Azure Portal resource screenshots** of a deployed Function App — is hard-blocked on a human-authenticated portal session (sign-in + MFA cannot run headlessly), and the `e2e-azure` workflow deletes its resources on teardown, so there is no live portal resource to capture in CI.

Rather than fabricate provenance or add manifest entries that would (correctly) fail the checker on missing PNGs, this PR ships a **drop-in handoff**: once a maintainer captures the PNGs, registration is a two-command, CI-green operation.

## Changes

- **`docs/screenshot-capture.md`** — runbook: which portal screens to capture, suggested filenames, the manifest entry template (as fenced YAML, not active data), hash refresh, embed, and cleanup reminder. Added to the mkdocs **Contributing** nav.
- **`Makefile`** — `make screenshots-check` (`--strict` verification) and `make screenshots-update` (recompute hashes).
- **`mkdocs.yml`** — nav entry for the runbook.

## Notes

- `docs/assets/screenshots.yml` is intentionally left **empty-seeded** — the checker treats an empty manifest as clean, so `make check-all` stays green with zero images present.
- `make screenshots-update` is meant to run **after** entries are added (per the runbook sequence). Running it on the empty manifest is a no-op that only rewrites formatting, so the runbook never calls it before entries exist.

## Verification

- `make check-all` — GREEN (ruff + mypy strict + pytest + bandit; coverage 98.31%).
- `make screenshots-check` — `Screenshot manifest OK: 0 screenshot(s) verified.`
- `mkdocs build` — new page builds clean; the only warning is a pre-existing broken link in `azure-functions-2.0-readiness.md`, unrelated to this PR.

## Out of scope

- Capturing and embedding the actual portal PNGs (requires a maintainer's authenticated portal session; tracked as the follow-up this runbook enables).