### PR TITLE
fix(endpoint): report request_body_required truthfully (#347)

### DIFF
--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -58,7 +58,7 @@ its own local conformance tests against the versioned dict convention.
 {
   "version": 1,                     // const 1; consumers WARN (not fail) on unknown
   "request_body": { /* JSON Schema */ } | null,
-  "request_body_required": true,    // default true unless every body field has a default
+  "request_body_required": true,    // true whenever a body model is configured (runtime rejects empty body)
   "parameters": [                   // OpenAPI parameter objects (query/path/header)
     { "name": "id", "in": "path", "required": true, "schema": { /* JSON Schema */ } }
   ],
@@ -148,7 +148,7 @@ requires plain JSON Schema with `$defs` left unresolved:
 | Ref template | Pydantic default `#/$defs/{model}` |
 | `$defs` | **left UNRESOLVED** — the consumer hoists them to `components/schemas` |
 | Generator class | Pydantic default `GenerateJsonSchema` (pin explicitly if customized; Pydantic minor bumps can change output) |
-| `request_body_required` | `True` unless every field of the body model has a default |
+| `request_body_required` | `True` whenever a body model is configured — the runtime unconditionally rejects an empty body with 422 regardless of field optionality (#347) |
 
 The response-schema mode above applies to **Pydantic-derived response-model
 schemas**. The `422` validation-error response schema is produced directly

--- a/src/azure_functions_validation/_endpoint.py
+++ b/src/azure_functions_validation/_endpoint.py
@@ -144,7 +144,12 @@ def build_endpoint_metadata(config: Any) -> EndpointMetadata:
     body = config.body
     if _is_model_type(body):
         request_body: dict[str, Any] | None = _model_schema(body, "validation")
-        request_body_required = any(field.is_required() for field in body.model_fields.values())
+        # The runtime adapter unconditionally rejects an empty body (422) whenever
+        # a body model is configured, regardless of individual field optionality,
+        # so the metadata must report the body as required to stay truthful to
+        # actual server behaviour (#347). Optional-body support, if ever added,
+        # must be an explicit opt-in that also relaxes the runtime 422.
+        request_body_required = True
     else:
         request_body = None
         request_body_required = False

--- a/tests/test_endpoint_write.py
+++ b/tests/test_endpoint_write.py
@@ -247,12 +247,12 @@ class TestCanonicalization:
 
         assert _endpoint_of(handler)["request_body_required"] is True
 
-    def test_request_body_required_false_when_all_optional(self) -> None:
+    def test_request_body_required_true_when_all_optional(self) -> None:
         @validate_http(body=AllOptional)
         def handler(req: func.HttpRequest, body: AllOptional) -> Any:
             return {}
 
-        assert _endpoint_of(handler)["request_body_required"] is False
+        assert _endpoint_of(handler)["request_body_required"] is True
 
     def test_path_parameter_always_required(self) -> None:
         @validate_http(path=PathParams)


### PR DESCRIPTION
## Summary
- The runtime adapter unconditionally rejects an empty body with 422 whenever a body model is configured, regardless of per-field optionality. The emitted metadata previously derived `request_body_required` from field-level optionality, so an all-optional body model advertised `request_body_required=false` while the server still rejected empty bodies — a lie in the contract.
- Make the metadata truthful to actual runtime behaviour: `request_body_required` is `True` whenever a body model is present. No-body endpoints stay `False`.
- Updated `docs/METADATA_SPEC.md` to describe the truthful behaviour and the affected test.

## Out of scope
- Real optional-body runtime semantics (empty body parsed as `{}`). Deferred: introduce an explicit `body_required=False` opt-in on `@validate_http` before relaxing the 422 behaviour.

## Verification
- `hatch run pytest --cov` — all pass, coverage **98.11%** (≥95% gate)
- `make lint` — clean
- `make typecheck` — clean

Closes #347