### PR TITLE
docs: add durable design note for required-body behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ leak to clients.
 - Smoke-tested examples live under `examples/`
 - Product requirements: `PRD.md`
 - Design principles: `DESIGN.md`
+- Design notes: [`docs/design/optional-body-347.md`](docs/design/optional-body-347.md) — why a configured body is always reported as required (#347)
 
 ## Ecosystem
 

--- a/docs/design/optional-body-347.md
+++ b/docs/design/optional-body-347.md
@@ -1,0 +1,59 @@
+# Design note: optional request body is an explicit opt-in (issue #347)
+
+Status: **Accepted** · Scope: `azure-functions-validation` · Issue:
+[#347](https://github.com/yeongseon/azure-functions-validation-python/issues/347)
+
+> This is a durable design decision, not a task. It exists so the decision below
+> is **not re-litigated** every time someone notices that a body model with only
+> optional fields still reports `request_body_required: true`.
+
+## Context
+
+`@validate_http(body=Model)` installs a runtime adapter that **unconditionally
+rejects an empty request body with a `422`** whenever a body model is
+configured — regardless of whether every field on that model is optional. The
+cross-package `endpoint` metadata (see [`METADATA_SPEC.md`](../METADATA_SPEC.md))
+therefore reports:
+
+```jsonc
+"request_body_required": true   // whenever a body model is configured
+```
+
+This keeps the emitted metadata **truthful to actual runtime behavior**: a
+consumer such as `azure-functions-openapi` documents the body as required
+because the server really does require it.
+
+## Decision
+
+1. **Metadata must never lie about the runtime.** As long as the runtime returns
+   `422` on an empty body when a body model is present, the metadata MUST report
+   `request_body_required: true`. The metadata layer must not independently
+   soften this to `false` based on field optionality — that would advertise a
+   contract the server does not honor.
+
+2. **Optional-body support, if ever added, is an explicit opt-in that ALSO
+   relaxes the runtime `422`.** It is not enough to flip the metadata flag. Any
+   future optional-body feature MUST:
+   - be **explicitly opted into** (e.g. a dedicated decorator argument), never
+     inferred from field optionality; and
+   - **relax the runtime 422** in the same change, so an empty body is actually
+     accepted end-to-end — keeping metadata and runtime in lockstep.
+
+3. **Do not implement it speculatively.** Optional-body support is deferred until
+   (a) the typed-query endpoint-metadata contract has stabilized, and (b) a real
+   user need appears. Absent both, the current always-required behavior stands.
+
+## Consequences
+
+- A body model with only optional fields still reports `request_body_required:
+  true`. This is intentional and correct given the runtime.
+- Anyone proposing to change this must change the **runtime and the metadata
+  together**, behind an explicit opt-in — not the metadata alone.
+
+## References
+
+- Issue [#347](https://github.com/yeongseon/azure-functions-validation-python/issues/347)
+- [`docs/METADATA_SPEC.md`](../METADATA_SPEC.md) — `request_body_required` row in
+  the canonicalization rules.
+- `src/azure_functions_validation/_endpoint.py` — `build_endpoint_metadata`
+  (the comment there points back to this note).

--- a/src/azure_functions_validation/_endpoint.py
+++ b/src/azure_functions_validation/_endpoint.py
@@ -148,7 +148,8 @@ def build_endpoint_metadata(config: Any) -> EndpointMetadata:
         # a body model is configured, regardless of individual field optionality,
         # so the metadata must report the body as required to stay truthful to
         # actual server behaviour (#347). Optional-body support, if ever added,
-        # must be an explicit opt-in that also relaxes the runtime 422.
+        # must be an explicit opt-in that also relaxes the runtime 422. See the
+        # durable design note: docs/design/optional-body-347.md.
         request_body_required = True
     else:
         request_body = None


### PR DESCRIPTION
## Context
Closes #353.

The endpoint metadata always reports a configured request body as required, because the runtime adapter rejects an empty body with 422 regardless of individual field optionality (#347). That rationale previously lived only in an inline comment, making it easy to "fix" the metadata to look optional and silently diverge from real server behaviour.

## What changed
- Add `docs/design/optional-body-347.md` — an ADR-style durable design note capturing the decision, the runtime constraint, and what an explicit opt-in would require.
- Reference the design note from the `_endpoint.py` comment so future editors find the rationale.
- Link the design note from the README Documentation section.

## Acceptance Checklist
- [x] Durable design note added under `docs/design/`
- [x] Code comment references the note
- [x] README links the note
- [x] `make lint` passes (ruff, mypy, bandit clean)

## Out of scope
- Any change to actual optional-body support or the runtime 422 behaviour — this PR is documentation only.