### PR TITLE
docs(validation): document typed-query endpoint-metadata contract for openapi consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ leak to clients.
 
 - Project docs live under `docs/`
 - Smoke-tested examples live under `examples/`
+- Endpoint metadata contract: [`docs/METADATA_SPEC.md`](docs/METADATA_SPEC.md) — the `endpoint` namespace payload (parameters, `in` mapping, `required` rules) that [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) consumes
 - Product requirements: `PRD.md`
 - Design principles: `DESIGN.md`
 

--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -119,11 +119,13 @@ Each field becomes one parameter object `{ "name", "in", "required", "schema" }`
   - `path` parameters are **always** `required: true` — a path segment cannot
     be absent from a matched route, regardless of the field's optionality.
   - `query` and `header` parameters are `required: true` only when the field
-    appears in the model's JSON Schema `required` list (i.e. it has no default
-    and is not `Optional`); otherwise `required: false`.
+    appears in the model's JSON Schema `required` list (i.e. it has no default);
+    otherwise `required: false`. This keys off the schema's `required` list, not
+    the annotation — a field typed `Optional[...]` with no default is still
+    required.
   - Body-required behaviour is separate: `request_body_required` is `true`
-    whenever a body model is configured (#347) — see the design note
-    [`optional-body-347.md`](design/optional-body-347.md).
+    whenever a body model is configured — see issue
+    [#347](https://github.com/yeongseon/azure-functions-validation-python/issues/347).
 - **`schema`** is the field's Pydantic-generated JSON Schema. If the field
   references a nested model via `$ref`, the parameter's `schema` carries a
   top-level `$defs` so the consumer can hoist it (the `$defs`-if-`$ref`

--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -95,6 +95,50 @@ The rest of this document describes rules that are **specific to
 are not obligations on the generic `endpoint` convention above; other producers
 of the namespace implement their own equivalents.
 
+### Parameter mapping and `required` rules (validation-specific)
+
+`@validate_http` accepts three parameter models — `query=`, `path=`, and
+`headers=` — and `build_endpoint_metadata` flattens each model's fields into
+OpenAPI parameter objects. The model argument determines the `in` location:
+
+| Decorator argument | Emitted `in` value |
+| --- | --- |
+| `query=Model` | `"query"` |
+| `path=Model` | `"path"` |
+| `headers=Model` | `"header"` |
+
+(Note the singular OpenAPI spelling `header`, not `headers`.) A body model
+does **not** produce `parameters` entries — it is emitted as `request_body`.
+
+Each field becomes one parameter object `{ "name", "in", "required", "schema" }`:
+
+- **`name`** uses the field's serialization alias (`by_alias=True`), so it
+  matches the wire contract rather than the Python attribute name. Configure
+  aliases with Pydantic v2 `Field(alias=...)` / `alias_generator`.
+- **`required`** rules:
+  - `path` parameters are **always** `required: true` — a path segment cannot
+    be absent from a matched route, regardless of the field's optionality.
+  - `query` and `header` parameters are `required: true` only when the field
+    appears in the model's JSON Schema `required` list (i.e. it has no default
+    and is not `Optional`); otherwise `required: false`.
+  - Body-required behaviour is separate: `request_body_required` is `true`
+    whenever a body model is configured (#347) — see the design note
+    [`optional-body-347.md`](design/optional-body-347.md).
+- **`schema`** is the field's Pydantic-generated JSON Schema. If the field
+  references a nested model via `$ref`, the parameter's `schema` carries a
+  top-level `$defs` so the consumer can hoist it (the `$defs`-if-`$ref`
+  invariant).
+
+#### Repeated / array query parameters
+
+There is no special "explode" flag in the payload. A repeated query parameter
+is modelled as an ordinary field whose schema is an array — e.g. a
+`list[str]` field emits `"schema": { "type": "array", "items": {…} }`. The
+consumer derives OpenAPI array/`explode` semantics from that array schema; the
+producer does not encode collection-style hints separately. Runtime parsing of
+repeated `req.params` into a list is the adapter's responsibility and is out of
+scope for this metadata contract.
+
 ### The `422` validation-error response (validation-specific)
 
 `@validate_http` returns a `422` on request-validation failure, so when the


### PR DESCRIPTION
## Context
Closes #352.

Typed query/path/header support already ships (`@validate_http(query=Model)` etc., emitted in the `endpoint` namespace consumed by `azure-functions-openapi`). This PR documents the cross-repo endpoint-metadata contract so consumers can rely on it and it does not drift.

## What changed
- Add a **"Parameter mapping and `required` rules"** section to `docs/METADATA_SPEC.md`:
  - `in`-location mapping: `query` -> `"query"`, `path` -> `"path"`, `headers` -> `"header"` (singular OpenAPI spelling); body is emitted as `request_body`, not a parameter.
  - `required` rules: `path` is always required; `query`/`header` are required only when the field is in the model's JSON Schema `required` list. Body-required (`request_body_required`, #347) is separate and cross-linked to the design note.
  - `by_alias=True` naming, and the `$defs`-if-`$ref` attachment for parameter schemas.
  - **Repeated/array query params**: represented as an ordinary field whose schema is an array (`type: array`); no separate explode flag.
- Link `METADATA_SPEC.md` from the README Documentation section and cross-link the openapi consumer.

## Acceptance Checklist
- [x] Emitted metadata schema documented (version, parameters, `request_body_required`) — already present; parameter section now complete.
- [x] query/path/header `in` mapping and `required` rules specified (incl. #347 body-required).
- [x] Pydantic v2 aliases and repeated/array query params noted.
- [x] Linked from README; openapi consumer cross-linked.
- [x] `make lint` passes.

## Out of scope
- Runtime parsing of repeated `req.params` into lists (adapter concern, not this metadata contract).