### PR TITLE
ci(validation): promote worker-nightly WorkerCompat lane toward a gating check

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -161,3 +161,65 @@ jobs:
 
           echo "Test matrix result was '${TEST_RESULT}'. Failing required check."
           exit 1
+
+  # azure-functions 2.x compatibility proof lane (issue #351), modeled on
+  # langgraph d433b63. This is a SINGLE representative 2.x lane, not a matrix:
+  # it builds the wheel, installs it, overrides the pyproject `<2.0.0` cap to
+  # pull `azure-functions>=2,<3`, and runs the opt-in WorkerCompat spike against
+  # the wheel-installed package.
+  #
+  # Gating decision (see docs/azure-functions-2.0-readiness.md): this lane runs
+  # on every non-docs PR as a VISIBLE compatibility signal, but it is
+  # intentionally NOT wired into the `ci-required` aggregation job, so it does
+  # not block merges. Worker/loader compatibility is existential, yet the
+  # runtime cap stays `<2.0.0` until 2.x is certified on real Azure via
+  # e2e-azure.yml; making this lane blocking before that certification would
+  # gate merges on an uncertified runtime. Promote it to a required check via
+  # branch protection once the cap is lifted. azure-functions 2.x declares
+  # Requires-Python >=3.13, so this lane pins Python 3.13.
+  azure-functions-2x:
+    name: azure-functions 2.x compat (Py 3.13)
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Build wheel
+        # Prove 2.x against a WHEEL-installed build, not an editable/source tree.
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+
+      - name: Install wheel with dev extra
+        run: pip install "$(ls dist/azure_functions_validation-*.whl)[dev]"
+
+      - name: Upgrade azure-functions to the 2.x line
+        # pyproject caps azure-functions <2.0.0 until 2.x is certified on real
+        # Azure (see docs/azure-functions-2.0-readiness.md). This lane
+        # deliberately overrides that cap to PROVE the WorkerCompat surface
+        # (signature override, no leaked kwargs, no __wrapped__, unannotated
+        # req, non-empty worker indexing) holds under 2.x. pip warns about the
+        # intentional override; that is expected.
+        run: pip install "azure-functions>=2,<3"
+
+      - name: Show resolved versions
+        run: pip show azure-functions pydantic | grep -E '^(Name|Version):'
+
+      - name: Run the WorkerCompat spike against the wheel + azure-functions 2.x
+        # The spike is opt-in: it is marked `compat2x` (excluded from the default
+        # addopts) and additionally gated on AZFUNC_2X_SPIKE=1. `-o addopts=`
+        # clears the default marker-exclusion + coverage flags; `-m compat2x`
+        # selects only the spike; `-o pythonpath=` clears the repo's src/tests
+        # pythonpath so the installed WHEEL is exercised, not the source tree.
+        env:
+          AZFUNC_2X_SPIKE: "1"
+        run: |
+          pytest -m compat2x -o addopts= -o pythonpath= \
+            tests/test_worker_compat_2x_spike.py -v

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -198,7 +198,12 @@ jobs:
           python -m build --wheel --outdir dist
 
       - name: Install wheel with dev extra
-        run: pip install "$(ls dist/azure_functions_validation-*.whl)[dev]"
+        # Use a PEP 508 direct reference (name[extra] @ file://ABS_PATH) so pip
+        # resolves the dev extra from the wheel metadata; pip does not parse
+        # extras from a bare local wheel path.
+        run: |
+          wheel="$(ls dist/azure_functions_validation-*.whl)"
+          pip install "azure-functions-validation[dev] @ file://$(readlink -f "$wheel")"
 
       - name: Upgrade azure-functions to the 2.x line
         # pyproject caps azure-functions <2.0.0 until 2.x is certified on real

--- a/docs/azure-functions-2.0-readiness.md
+++ b/docs/azure-functions-2.0-readiness.md
@@ -127,3 +127,23 @@ pytest -m compat2x -o addopts='' tests/test_worker_compat_2x_spike.py
 
 If the spike passes cleanly, capture the `azure-functions` version and attach it
 to the tracking issue as evidence toward the cap-lift checklist above.
+
+## CI proof lane (issue #351)
+
+The spike also runs automatically as the `azure-functions 2.x compat (Py 3.13)`
+job in `.github/workflows/ci-test.yml` (modeled on langgraph `d433b63`). That
+job builds the wheel, installs it, overrides the `<2.0.0` cap with
+`azure-functions>=2,<3`, and runs the `compat2x` spike against the
+wheel-installed package with `AZFUNC_2X_SPIKE=1` and `-o pythonpath=`.
+
+**Gating decision — visible signal, not a merge blocker.** The lane runs on
+every non-docs PR so 2.x worker/loader regressions surface early, but it is
+deliberately **not** wired into the `ci-required` aggregation check. Worker
+compatibility is existential, yet the runtime cap stays `<2.0.0` until 2.x is
+certified on real Azure via `e2e-azure.yml`; making the lane blocking before
+that certification would gate merges on an uncertified runtime (and on the
+availability of a 2.x build on PyPI). Promote it to a required status check via
+branch protection at the same time the cap is lifted.
+
+A single representative 3.13 lane is used intentionally — not a version matrix —
+to keep CI cost bounded, since 2.x declares `Requires-Python >=3.13`.


### PR DESCRIPTION
## Context
Closes #351.

A `worker-nightly.yml` lane and the `compat2x` WorkerCompat spike (`tests/test_worker_compat_2x_spike.py`) already exist. This PR promotes that proof toward a **gating signal** by wiring it into `ci-test.yml` as a bounded, single-lane job modeled on langgraph `d433b63`.

## What changed
- **`.github/workflows/ci-test.yml`** — add `azure-functions 2.x compat (Py 3.13)` job:
  - builds the wheel, installs it with the `dev` extra,
  - overrides the pyproject `<2.0.0` cap with `azure-functions>=2,<3`,
  - runs the `compat2x` spike against the **wheel-installed** package with `AZFUNC_2X_SPIKE=1`, `-o addopts=`, `-m compat2x`, and `-o pythonpath=` (so the wheel, not the source tree, is exercised).
  - Gated with `needs: changes` / `if docs_only != 'true'` to skip docs-only PRs.
- **`docs/azure-functions-2.0-readiness.md`** — document the gating tradeoff and promotion path.

## Gating decision (documented tradeoff)
The lane runs on every non-docs PR as a **visible** compatibility signal, but is **intentionally not** wired into the `ci-required` aggregation check, so it does not block merges. Worker compatibility is existential, yet the runtime cap stays `<2.0.0` until 2.x is certified on real Azure via `e2e-azure.yml`; making it blocking before that certification would gate merges on an uncertified runtime (and on 2.x availability on PyPI). Promote to a required status check via branch protection when the cap is lifted.

## Cost bound
A single representative Python 3.13 lane (2.x declares `Requires-Python >=3.13`), **not** a version matrix.

## Acceptance Checklist
- [x] Wheel-install + `azure-functions>=2,<3` compat job modeled on langgraph `d433b63` (Py 3.13).
- [x] Gating vs nightly-only decided and documented (visible signal, non-blocking until cap lift).
- [x] CI cost bounded (single 2.x lane, no matrix).
- [x] Spike selection/markers verified locally (6 passed).