### PR TITLE
ci: notify cookbook to re-run e2e after PyPI release

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -306,3 +306,26 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1 # pin-exempt: PyPA official publisher (trusted-publisher OIDC); tracks release/v1 by design
+
+  notify-cookbook:
+    name: Trigger cookbook e2e re-verification
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    env:
+      # Cross-repo repository_dispatch needs a token with contents:write on the
+      # cookbook repo (GITHUB_TOKEN cannot cross repositories). Supply a PAT or
+      # GitHub App token via the COOKBOOK_DISPATCH_TOKEN secret. When it is unset
+      # the step is skipped, so missing wiring never fails a release.
+      DISPATCH_TOKEN: ${{ secrets.COOKBOOK_DISPATCH_TOKEN }}
+    steps:
+      - name: Dispatch sibling-release to cookbook
+        if: ${{ env.DISPATCH_TOKEN != '' }}
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          curl -sSf -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/yeongseon/azure-functions-cookbook-python/dispatches \
+            -d "{\"event_type\":\"sibling-release\",\"client_payload\":{\"library\":\"azure-functions-validation\",\"version\":\"${VERSION}\"}}"


### PR DESCRIPTION
## Summary
- Adds a `notify-cookbook` job to `publish-pypi.yml` that fires a `repository_dispatch` (`sibling-release`) to `yeongseon/azure-functions-cookbook-python` after a successful `build` + `publish`, so the cookbook re-runs its toolkit e2e matrix against the freshly published version.
- Payload carries `library` + published `version`.
- The dispatch step is guarded on `COOKBOOK_DISPATCH_TOKEN`; when the secret is unset the step is skipped, so missing wiring never fails a release.

## Follow-up (owner action, out of scope)
- Add the `COOKBOOK_DISPATCH_TOKEN` secret (cross-repo PAT / GitHub App token with `contents:write` on the cookbook repo). `GITHUB_TOKEN` cannot cross repositories.

Closes #361