### PR TITLE
docs: wire WorkerCompat tests + nightly to central worker-binding page

### DIFF
--- a/.github/workflows/worker-nightly.yml
+++ b/.github/workflows/worker-nightly.yml
@@ -50,6 +50,6 @@ jobs:
       - name: Explain a WorkerCompat break
         if: failure()
         run: |
-          echo "::error::WorkerCompat suite failed against the latest pre-release azure-functions worker."
-          echo "This usually means an upstream worker/loader change broke signature-override, annotation clearing, or safe-metadata copying."
+          echo "::error::WorkerCompat suite failed against the latest pre-release azure-functions package."
+          echo "This job upgrades the azure-functions library (which proxies worker/loader behavior); a failure usually means an upstream change broke signature-override, annotation clearing, or safe-metadata copying."
           echo "See the mechanism this suite protects: https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/"

--- a/.github/workflows/worker-nightly.yml
+++ b/.github/workflows/worker-nightly.yml
@@ -46,3 +46,10 @@ jobs:
         run: |
           hatch run pytest tests/test_decorator.py tests/test_integration.py \
             -v --no-header -p no:cacheprovider --no-cov
+
+      - name: Explain a WorkerCompat break
+        if: failure()
+        run: |
+          echo "::error::WorkerCompat suite failed against the latest pre-release azure-functions worker."
+          echo "This usually means an upstream worker/loader change broke signature-override, annotation clearing, or safe-metadata copying."
+          echo "See the mechanism this suite protects: https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ flowchart LR
     AD2 --> RESP([HttpResponse])
 ```
 
+> **Decorator order and parameter passthrough:** `@validate_http` must sit directly beneath `@app.route(...)` so the Azure Functions worker still sees a handler whose parameters it can bind by name (`req`, `context`, and your validated models). The worker's name-binding contract — and this repo's WorkerCompat tests that verify it — is explained in [How the worker binds handlers](https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/).
+
 ## Before / After
 
 <details>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ flowchart LR
     AD2 --> RESP([HttpResponse])
 ```
 
-> **Decorator order and parameter passthrough:** `@validate_http` must sit directly beneath `@app.route(...)` so the Azure Functions worker still sees a handler whose parameters it can bind by name (`req`, `context`, and your validated models). The worker's name-binding contract — and this repo's WorkerCompat tests that verify it — is explained in [How the worker binds handlers](https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/).
+> **Decorator order and parameter passthrough:** `@validate_http` must sit directly beneath `@app.route(...)` so the Azure Functions worker still sees a bindable handler signature. WorkerCompat deliberately hides the validation-injected models from the worker-visible signature, so the worker binds only `req` (plus any declared input/output binding params like `context`) by name; `@validate_http` then injects the validated models at runtime. The worker's name-binding contract — and this repo's WorkerCompat tests that verify it — is explained in [How the worker binds handlers](https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/).
 
 ## Before / After
 

--- a/docs/METADATA_SPEC.md
+++ b/docs/METADATA_SPEC.md
@@ -19,6 +19,8 @@ Status: **v1** · Owner namespace: `endpoint` · Issue: [#271](https://github.co
 
 ## Purpose
 
+> **Relationship to the worker contract:** This document is the *cross-package* contract (how sibling packages exchange `endpoint` metadata). The platform's *worker contract* — how the Azure Functions worker binds handler parameters by name — is explained separately in [How the worker binds handlers](https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/). This page = cross-package convention; the worker-binding page = platform runtime contract.
+
 The Azure Functions Python DX Toolkit lets sibling packages cooperate without
 importing one another. Decorators attach a single dict to the wrapped handler
 under the conventional attribute `_azure_functions_metadata`, keyed by a

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -78,6 +78,8 @@ def my_handler(req: func.HttpRequest, body: MyBodyModel) -> dict[str, str]:
     return {"ok": "true"}
 ```
 
+Decorator order matters because the Azure Functions worker binds handler parameters by **name**, and `@validate_http` must wrap the handler without disturbing the worker's signature introspection. For the underlying mechanism see [How the worker binds handlers §2–§3](https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/) (parameter passthrough and `req`/`context` resolution). This repo's WorkerCompat suite (`tests/test_decorator.py`, `tests/test_worker_compat_2x_spike.py`) is the executable proof of that contract.
+
 ### Problem: expected body validation but got `400 Invalid JSON`
 
 Cause:


### PR DESCRIPTION
## Context
Wires this repo's existing WorkerCompat verification and error surfaces to the central Platform mechanics page [How the worker binds handlers](https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/), which cites these tests as proof of the worker's name-binding contract. No new tests or behavior changes — this only makes the existing verification discoverable and routes readers from error surfaces to the mechanism explanation.

## Changes
- **`.github/workflows/worker-nightly.yml`** — added an `if: failure()` step that prints the worker-binding page URL so a nightly break points to the mechanism explanation.
- **`docs/troubleshooting.md`** — linked the decorator-order fix pattern to the page (§2/§3 passthrough and `req`/`context` resolution) and named the WorkerCompat suite as executable proof.
- **`README.md`** — added a decorator-order / parameter-passthrough note under "How it works" linking to the page.
- **`docs/METADATA_SPEC.md`** — one-line relationship: this page = cross-package convention; the worker-binding page = platform runtime contract.

## Out of scope
- Writing new tests or changing WorkerCompat behavior.
- Lifting the `azure-functions<2.0.0` cap (#350).

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow: OK.
- `mkdocs build --strict`: the only warning is pre-existing and unrelated (`azure-functions-2.0-readiness.md` broken link), confirmed identical on clean `main`.

Closes #363